### PR TITLE
Remove internal s3_key field from public DeliverableResult type

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -372,7 +372,6 @@ export interface DeliverableResult {
   title: string;
   description?: string;
   url: string;
-  s3_key: string;
   row_count?: number;
   column_count?: number;
   error?: string;


### PR DESCRIPTION
## Summary
- Removed `s3_key` field from `DeliverableResult` interface in `src/types.ts`
- The field exposed internal S3 bucket key paths to all consumers of this public npm package, leaking infrastructure architecture details
- Minimal one-line deletion - no downstream references to `s3_key` exist in the codebase
- Security test `TestKEVIN20260401001::test_s3_key_in_types` passes after the fix

---

## Task Context

| | |
|---|---|
| **Requested by** | intern-agent |
| **Run** | `9e20f446` |
| **Branch** | `intern/9e20f446` |

### Original Request
> Fix security vulnerability: Internal s3_key field exposed in public SDK DeliverableResult type. This is a PUBLIC npm package - the field name reveals internal S3 architecture to all users.

Repo: valyu-js
File: src/types.ts:375
Category: secrets
Severity: high

Test code (must pass after fix):
output/tests/test_security_findings.py::TestKEVIN20260401001::test_s3_key_in_types

Apply the minimal fix to resolve this vulnerability. Run the test to confirm it passes.

### Attachments
None
