### PR TITLE
Add per-tool max_calls override and browser_use tool

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "valyu-js",
-  "version": "2.7.9",
+  "version": "2.7.10",
   "description": "Deepsearch API for AI.",
   "files": [
     "dist"

--- a/src/index.ts
+++ b/src/index.ts
@@ -2220,6 +2220,7 @@ export type {
   DeepResearchUsage,
   DeepResearchCostBreakdown,
   DeepResearchTools,
+  ToolConfig,
   DeepResearchCreateResponse,
   DeepResearchStatusResponse,
   DeepResearchTaskListItem,

--- a/src/types.ts
+++ b/src/types.ts
@@ -390,9 +390,26 @@ export interface DeepResearchSearchConfig {
   countryCode?: CountryCode; // Country code for location-filtered searches
 }
 
+/**
+ * Per-tool configuration with optional call limit.
+ *
+ * System defaults for max_calls:
+ * - browser_use: 5
+ * - screenshots: 15
+ * - code_execution: 10
+ *
+ * max_calls can only be lowered, not raised above the system default.
+ * Setting max_calls to 0 effectively disables the tool.
+ */
+export interface ToolConfig {
+  enabled?: boolean;
+  max_calls?: number;
+}
+
 export interface DeepResearchTools {
-  code_execution?: boolean;
-  screenshots?: boolean;
+  code_execution?: boolean | ToolConfig;
+  screenshots?: boolean | ToolConfig;
+  browser_use?: boolean | ToolConfig;
 }
 
 export interface DeepResearchCreateOptions {


### PR DESCRIPTION
## Summary
- Add `ToolConfig` interface with `enabled` and `max_calls` fields
- Update `DeepResearchTools` so each tool (`code_execution`, `screenshots`, new `browser_use`) accepts `boolean | ToolConfig`
- `max_calls` lets users cap per-tool invocations to manage costs (capped at system defaults: browser_use=5, screenshots=15, code_execution=10)
- Export `ToolConfig` from types
- Bump version 2.7.9 → 2.7.10

## Test plan
- [ ] Verify `DeepResearchTools` accepts both boolean and object formats
- [ ] Verify payload serialization passes object format to API correctly
- [ ] Verify backward compatibility with existing `tools: { code_execution: true }` calls