### PR TITLE
Mark s3_key as internal in DeliverableResult SDK type

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -373,7 +373,8 @@ export interface DeliverableResult {
   title: string;
   description?: string;
   url: string;
-  s3_key: string;
+  /** @internal */
+  s3_key?: string;
   row_count?: number;
   column_count?: number;
   error?: string;
@@ -549,8 +550,8 @@ export interface DeepResearchStatusResponse {
   sources?: DeepResearchSource[];
   cost?: number; // Total cost in dollars (preferred)
   usage?: DeepResearchUsage; // Detailed cost breakdown (backward compatible)
-  cost_breakdown?: DeepResearchCostBreakdown;  // Itemized cost breakdown
-  tools?: DeepResearchTools;  // Resolved tools configuration
+  cost_breakdown?: DeepResearchCostBreakdown; // Itemized cost breakdown
+  tools?: DeepResearchTools; // Resolved tools configuration
   batch_id?: string; // Batch ID if task belongs to a batch
   batch_task_id?: string; // Batch task ID if task belongs to a batch
   hitl_config?: Record<string, boolean>; // HITL configuration (mirrors request hitl param)
@@ -625,7 +626,13 @@ export interface WaitOptions {
   pollInterval?: number;
   maxWaitTime?: number;
   onProgress?: (status: DeepResearchStatusResponse) => void;
-  onInteraction?: (interaction: Interaction) => Promise<Record<string, any> | null | undefined> | Record<string, any> | null | undefined;
+  onInteraction?: (
+    interaction: Interaction,
+  ) =>
+    | Promise<Record<string, any> | null | undefined>
+    | Record<string, any>
+    | null
+    | undefined;
 }
 
 export interface StreamCallback {


### PR DESCRIPTION
## Summary
- Marked `s3_key` field in `DeliverableResult` interface as `/** @internal */` and optional (`?`)
- This prevents SDK users and documentation generators from treating `s3_key` as part of the public API
- The field is an internal S3 object key that could reveal storage architecture or enable bucket enumeration if misconfigured
- Field is kept in the type (not removed) to maintain backwards compatibility for any existing consumers

---

## Task Context

| | |
|---|---|
| **Requested by** | intern-agent |
| **Run** | `94af8517` |
| **Branch** | `intern/94af8517` |

### Original Request
> Fix security vulnerability: s3_key field exposed in public valyu-js SDK types (DeliverableResult interface). This reveals internal S3 storage architecture to all SDK users. The field contains an S3 object key that could enable bucket enumeration if the bucket is ever misconfigured.

Repo: valyu-js
File: src/types.ts:376
Category: config
Severity: high

Test code (must pass after fix):
def test_s3_key_in_valyu_js():
    content = open('/workspace/repos/valyu-js/src/types.ts').read()
    assert 's3_key' in content

Apply the minimal fix to resolve this vulnerability. Run the test to confirm it passes.

### Attachments
None
