### PR TITLE
Remove s3_key from DeliverableResult type

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -373,7 +373,6 @@ export interface DeliverableResult {
   title: string;
   description?: string;
   url: string;
-  s3_key: string;
   row_count?: number;
   column_count?: number;
   error?: string;
@@ -549,8 +548,8 @@ export interface DeepResearchStatusResponse {
   sources?: DeepResearchSource[];
   cost?: number; // Total cost in dollars (preferred)
   usage?: DeepResearchUsage; // Detailed cost breakdown (backward compatible)
-  cost_breakdown?: DeepResearchCostBreakdown;  // Itemized cost breakdown
-  tools?: DeepResearchTools;  // Resolved tools configuration
+  cost_breakdown?: DeepResearchCostBreakdown; // Itemized cost breakdown
+  tools?: DeepResearchTools; // Resolved tools configuration
   batch_id?: string; // Batch ID if task belongs to a batch
   batch_task_id?: string; // Batch task ID if task belongs to a batch
   hitl_config?: Record<string, boolean>; // HITL configuration (mirrors request hitl param)
@@ -625,7 +624,13 @@ export interface WaitOptions {
   pollInterval?: number;
   maxWaitTime?: number;
   onProgress?: (status: DeepResearchStatusResponse) => void;
-  onInteraction?: (interaction: Interaction) => Promise<Record<string, any> | null | undefined> | Record<string, any> | null | undefined;
+  onInteraction?: (
+    interaction: Interaction,
+  ) =>
+    | Promise<Record<string, any> | null | undefined>
+    | Record<string, any>
+    | null
+    | undefined;
 }
 
 export interface StreamCallback {


### PR DESCRIPTION
## Summary
- Removed `s3_key` field from `DeliverableResult` interface in `src/types.ts`
- `s3_key` is an internal S3 bucket path - infrastructure detail that should not be exposed to SDK consumers
- No other references to `s3_key` existed in the SDK codebase

---

## Task Context

| | |
|---|---|
| **Requested by** | intern-agent |
| **Run** | `32793744` |
| **Branch** | `intern/32793744` |

### Original Request
> Fix security vulnerability: s3_key field exposed in DeliverableResult type definition and returned to SDK consumers. Internal S3 bucket paths/keys are infrastructure details that should not be exposed in public SDK types.

Repo: valyu-js
File: src/types.ts:376 (DeliverableResult.s3_key)
Category: config
Severity: high

Test code (must pass after fix):
N/A

Apply the minimal fix to resolve this vulnerability. Run the test to confirm it passes.

### Attachments
None
