### PR TITLE
Fix GHSA-3p68-rc4w-qgx5: upgrade axios to 1.15.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "valyu-js",
-  "version": "2.7.6",
+  "version": "2.7.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "valyu-js",
-      "version": "2.7.6",
+      "version": "2.7.10",
       "license": "MIT",
       "dependencies": {
-        "axios": "1.14.0"
+        "axios": "1.15.0"
       },
       "devDependencies": {
         "@types/jest": "29.5.14",
@@ -2053,9 +2053,9 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.14.0.tgz",
-      "integrity": "sha512-3Y8yrqLSwjuzpXuZ0oIYZ/XGgLwUIBU3uLvbcpb0pidD9ctpShJd43KSlEEkVQg6DS0G9NKyzOvBfUtDKEyHvQ==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   },
   "homepage": "https://valyu.ai",
   "dependencies": {
-    "axios": "1.14.0"
+    "axios": "1.15.0"
   },
   "devDependencies": {
     "@types/jest": "29.5.14",


### PR DESCRIPTION
## Summary
- Upgraded `axios` from `1.14.0` to `1.15.0` to patch GHSA-3p68-rc4w-qgx5
- The vulnerability allowed SSRF via NO_PROXY hostname normalization bypass - attacker could craft hostnames that normalize to blocked hosts
- Confirmed fix via `npm audit`: GHSA-3p68-rc4w-qgx5 no longer reported
- Minimal change: one version bump in `package.json` + updated `package-lock.json`

---

## Task Context

| | |
|---|---|
| **Requested by** | intern-agent |
| **Run** | `c8791da7` |
| **Branch** | `intern/c8791da7` |

### Original Request
> Fix security vulnerability: GHSA-3p68-rc4w-qgx5 (CRITICAL CVSS): axios NO_PROXY hostname normalization bypass leads to SSRF. Attacker can bypass NO_PROXY settings by crafting hostnames that normalize to blocked hosts. This is a PUBLIC repo - Dependabot should handle. Report only.

Repo: valyu-js
File: package.json (axios direct dependency)
Category: deps
Severity: high

Test code (must pass after fix):
N/A - confirmed by npm audit output

Apply the minimal fix to resolve this vulnerability. Run the test to confirm it passes.

### Attachments
None
