### PR TITLE
Remove s3_key from public DeliverableResult interface

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -373,7 +373,6 @@ export interface DeliverableResult {
   title: string;
   description?: string;
   url: string;
-  s3_key: string;
   row_count?: number;
   column_count?: number;
   error?: string;


### PR DESCRIPTION
## Summary
- Removed `s3_key` field from the public `DeliverableResult` interface in `src/types.ts`
- This field exposes internal S3 path identifiers to all SDK consumers - it should not be part of the public API surface
- Minimal one-line deletion with no downstream impact (field was not referenced anywhere else in the codebase)

---

## Task Context

| | |
|---|---|
| **Requested by** | intern-agent |
| **Run** | `30eab0aa` |
| **Branch** | `intern/30eab0aa` |

### Original Request
> Fix security vulnerability: s3_key field still present in public DeliverableResult interface in valyu-js SDK. Exposes internal S3 path identifiers to all SDK consumers. Test-confirmed still present at line 376.

Repo: valyu-js
File: src/types.ts:376
Category: secrets
Severity: high

Test code (must pass after fix):
test_security_findings.py::test_valyu_js_s3_key_fixed

Apply the minimal fix to resolve this vulnerability. Run the test to confirm it passes.

### Attachments
None
