### PR TITLE
Remove internal api_key_id and credit_id from DeepResearchBatch type

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -549,8 +549,8 @@ export interface DeepResearchStatusResponse {
   sources?: DeepResearchSource[];
   cost?: number; // Total cost in dollars (preferred)
   usage?: DeepResearchUsage; // Detailed cost breakdown (backward compatible)
-  cost_breakdown?: DeepResearchCostBreakdown;  // Itemized cost breakdown
-  tools?: DeepResearchTools;  // Resolved tools configuration
+  cost_breakdown?: DeepResearchCostBreakdown; // Itemized cost breakdown
+  tools?: DeepResearchTools; // Resolved tools configuration
   batch_id?: string; // Batch ID if task belongs to a batch
   batch_task_id?: string; // Batch task ID if task belongs to a batch
   hitl_config?: Record<string, boolean>; // HITL configuration (mirrors request hitl param)
@@ -625,7 +625,13 @@ export interface WaitOptions {
   pollInterval?: number;
   maxWaitTime?: number;
   onProgress?: (status: DeepResearchStatusResponse) => void;
-  onInteraction?: (interaction: Interaction) => Promise<Record<string, any> | null | undefined> | Record<string, any> | null | undefined;
+  onInteraction?: (
+    interaction: Interaction,
+  ) =>
+    | Promise<Record<string, any> | null | undefined>
+    | Record<string, any>
+    | null
+    | undefined;
 }
 
 export interface StreamCallback {
@@ -661,8 +667,6 @@ export interface BatchCounts {
 export interface DeepResearchBatch {
   batch_id: string;
   organisation_id: string;
-  api_key_id: string;
-  credit_id: string;
   status: BatchStatus;
   mode: DeepResearchMode; // Renamed from 'model' in responses
   name?: string;


### PR DESCRIPTION
## Summary
- Remove `api_key_id` and `credit_id` fields from `DeepResearchBatch` interface in `src/types.ts`
- These fields expose internal database IDs in the public SDK, leaking Valyu's data model structure to API consumers
- Only change is removing the two fields - no runtime logic affected since types are compile-time only
- Prettier reformatted a long `WaitOptions` callback signature and two trailing-space comments as a side effect

---

## Task Context

| | |
|---|---|
| **Requested by** | intern-agent |
| **Run** | `1d74f322` |
| **Branch** | `intern/1d74f322` |

### Original Request
> Fix security vulnerability: api_key_id and credit_id fields exposed in DeepResearchBatch types in public SDK. Internal database IDs returned in batch polling responses, revealing internal data model structure.

Repo: valyu-js
File: src/types.ts (DeepResearchBatch types)
Category: secrets
Severity: high

Test code (must pass after fix):
test_security_findings.py::test_deepresearch_batch_internal_ids

Apply the minimal fix to resolve this vulnerability. Run the test to confirm it passes.

### Attachments
None
