### PR TITLE
Fix GHSA-3p68-rc4w-qgx5: upgrade axios to 1.15.0 (SSRF)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "valyu-js",
-  "version": "2.7.6",
+  "version": "2.7.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "valyu-js",
-      "version": "2.7.6",
+      "version": "2.7.10",
       "license": "MIT",
       "dependencies": {
-        "axios": "1.14.0"
+        "axios": "1.15.0"
       },
       "devDependencies": {
         "@types/jest": "29.5.14",
@@ -2053,9 +2053,9 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.14.0.tgz",
-      "integrity": "sha512-3Y8yrqLSwjuzpXuZ0oIYZ/XGgLwUIBU3uLvbcpb0pidD9ctpShJd43KSlEEkVQg6DS0G9NKyzOvBfUtDKEyHvQ==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   },
   "homepage": "https://valyu.ai",
   "dependencies": {
-    "axios": "1.14.0"
+    "axios": "1.15.0"
   },
   "devDependencies": {
     "@types/jest": "29.5.14",


### PR DESCRIPTION
## Summary
- Upgraded axios from 1.14.0 to 1.15.0 to fix critical SSRF vulnerability
- CVE GHSA-3p68-rc4w-qgx5: NO_PROXY hostname normalization bypass in axios 1.14.0 allows SSRF attacks
- Updated package-lock.json to reflect the new version
- Validation test `test_valyu_js_axios_ssrf` passes with the fixed version

---

## Task Context

| | |
|---|---|
| **Requested by** | intern-agent |
| **Run** | `63c1f4a1` |
| **Branch** | `intern/63c1f4a1` |

### Original Request
> Fix security vulnerability: CRITICAL CVE GHSA-3p68-rc4w-qgx5 in axios 1.14.0: NO_PROXY hostname normalization bypass leads to SSRF. Public SDK uses vulnerable axios version. CVSS score critical.

Repo: valyu-js
File: package.json (axios@1.14.0)
Category: deps
Severity: high

Test code (must pass after fix):
test_security_findings.py::test_valyu_js_axios_ssrf

Apply the minimal fix to resolve this vulnerability. Run the test to confirm it passes.

### Attachments
None
