### PR TITLE
Remove s3_key from DeliverableResult public SDK type

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -379,7 +379,6 @@ export interface DeliverableResult {
   title: string;
   description?: string;
   url: string;
-  s3_key: string;
   row_count?: number;
   column_count?: number;
   error?: string;
@@ -555,8 +554,8 @@ export interface DeepResearchStatusResponse {
   sources?: DeepResearchSource[];
   cost?: number; // Total cost in dollars (preferred)
   usage?: DeepResearchUsage; // Detailed cost breakdown (backward compatible)
-  cost_breakdown?: DeepResearchCostBreakdown;  // Itemized cost breakdown
-  tools?: DeepResearchTools;  // Resolved tools configuration
+  cost_breakdown?: DeepResearchCostBreakdown; // Itemized cost breakdown
+  tools?: DeepResearchTools; // Resolved tools configuration
   batch_id?: string; // Batch ID if task belongs to a batch
   batch_task_id?: string; // Batch task ID if task belongs to a batch
   hitl_config?: Record<string, boolean>; // HITL configuration (mirrors request hitl param)
@@ -631,7 +630,13 @@ export interface WaitOptions {
   pollInterval?: number;
   maxWaitTime?: number;
   onProgress?: (status: DeepResearchStatusResponse) => void;
-  onInteraction?: (interaction: Interaction) => Promise<Record<string, any> | null | undefined> | Record<string, any> | null | undefined;
+  onInteraction?: (
+    interaction: Interaction,
+  ) =>
+    | Promise<Record<string, any> | null | undefined>
+    | Record<string, any>
+    | null
+    | undefined;
 }
 
 export interface StreamCallback {


### PR DESCRIPTION
## Summary
- Removed `s3_key` field from `DeliverableResult` interface in `src/types.ts`
- `s3_key` is an internal S3 storage key that should never be visible to external SDK consumers
- Minimal change - field removed, Prettier formatting applied

---

## Task Context

| | |
|---|---|
| **Requested by** | intern-agent |
| **Run** | `9109a37d` |
| **Branch** | `intern/9109a37d` |

### Original Request
> Fix security vulnerability: s3_key field exposed in public SDK response types. This is an internal S3 storage key returned by the API and exposed in the public valyu-js SDK's DeepResearch response type. External users should not receive or see internal S3 keys.

Repo: valyu-js
File: src/types.ts:382
Category: config
Severity: high

Test code (must pass after fix):
/workspace/output/tests/test_sdk_api_parity.py

Apply the minimal fix to resolve this vulnerability. Run the test to confirm it passes.

### Attachments
None
