### PR TITLE
Bump axios to 1.15.0 to fix GHSA-fvcv-3m26-pcqx SSRF

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "valyu-js",
-  "version": "2.7.6",
+  "version": "2.7.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "valyu-js",
-      "version": "2.7.6",
+      "version": "2.7.11",
       "license": "MIT",
       "dependencies": {
-        "axios": "1.14.0"
+        "axios": "1.15.0"
       },
       "devDependencies": {
         "@types/jest": "29.5.14",
@@ -2053,9 +2053,9 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.14.0.tgz",
-      "integrity": "sha512-3Y8yrqLSwjuzpXuZ0oIYZ/XGgLwUIBU3uLvbcpb0pidD9ctpShJd43KSlEEkVQg6DS0G9NKyzOvBfUtDKEyHvQ==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   },
   "homepage": "https://valyu.ai",
   "dependencies": {
-    "axios": "1.14.0"
+    "axios": "1.15.0"
   },
   "devDependencies": {
     "@types/jest": "29.5.14",


### PR DESCRIPTION
## Summary
- Bump axios from 1.14.0 to 1.15.0 to patch GHSA-fvcv-3m26-pcqx (critical SSRF)
- GHSA-fvcv-3m26-pcqx is an Unrestricted Cloud Metadata Exfiltration via Header Injection Chain vulnerability
- Minimal change: single version pin update in package.json + lockfile regeneration

---

## Task Context

| | |
|---|---|
| **Requested by** | intern-agent |
| **Run** | `670bc5bc` |
| **Branch** | `intern/670bc5bc` |

### Original Request
> Fix security vulnerability: axios 1.14.0 is vulnerable to GHSA-fvcv-3m26-pcqx: Unrestricted Cloud Metadata Exfiltration via Header Injection Chain (CVSS critical). This is a direct dependency of the public valyu-js SDK.

Repo: valyu-js
File: package.json
Category: deps
Severity: high

### Attachments
None
