### PR TITLE
Remove s3_key from public DeliverableResult interface

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -379,7 +379,6 @@ export interface DeliverableResult {
   title: string;
   description?: string;
   url: string;
-  s3_key: string;
   row_count?: number;
   column_count?: number;
   error?: string;
@@ -555,8 +554,8 @@ export interface DeepResearchStatusResponse {
   sources?: DeepResearchSource[];
   cost?: number; // Total cost in dollars (preferred)
   usage?: DeepResearchUsage; // Detailed cost breakdown (backward compatible)
-  cost_breakdown?: DeepResearchCostBreakdown;  // Itemized cost breakdown
-  tools?: DeepResearchTools;  // Resolved tools configuration
+  cost_breakdown?: DeepResearchCostBreakdown; // Itemized cost breakdown
+  tools?: DeepResearchTools; // Resolved tools configuration
   batch_id?: string; // Batch ID if task belongs to a batch
   batch_task_id?: string; // Batch task ID if task belongs to a batch
   hitl_config?: Record<string, boolean>; // HITL configuration (mirrors request hitl param)
@@ -631,7 +630,13 @@ export interface WaitOptions {
   pollInterval?: number;
   maxWaitTime?: number;
   onProgress?: (status: DeepResearchStatusResponse) => void;
-  onInteraction?: (interaction: Interaction) => Promise<Record<string, any> | null | undefined> | Record<string, any> | null | undefined;
+  onInteraction?: (
+    interaction: Interaction,
+  ) =>
+    | Promise<Record<string, any> | null | undefined>
+    | Record<string, any>
+    | null
+    | undefined;
 }
 
 export interface StreamCallback {


### PR DESCRIPTION
## Summary
- Removed \`s3_key\` field from the public \`DeliverableResult\` interface in \`src/types.ts\`
- \`s3_key\` is an internal S3 storage key that should never be visible to SDK users - it could enable enumeration of other users' deliverables via bucket traversal
- The \`url\` field already provides the download link; \`s3_key\` is not needed by SDK consumers
- Security severity: high (KEVIN-20260401-001)

---

## Task Context

| | |
|---|---|
| **Requested by** | intern-agent |
| **Run** | \`eb774117\` |
| **Branch** | \`intern/eb774117\` |

### Original Request
> Fix security vulnerability: s3_key field is present in the public Deliverable interface in the valyu-js SDK. This exposes internal S3 storage key paths to all SDK users, potentially enabling enumeration of other users' deliverables via bucket traversal.