### PR TITLE
Regenerate lock file for axios 1.15.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "valyu-js",
-  "version": "2.7.6",
+  "version": "2.7.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "valyu-js",
-      "version": "2.7.6",
+      "version": "2.7.12",
       "license": "MIT",
       "dependencies": {
-        "axios": "1.14.0"
+        "axios": "^1.15.0"
       },
       "devDependencies": {
         "@types/jest": "29.5.14",
@@ -2053,9 +2053,9 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.14.0.tgz",
-      "integrity": "sha512-3Y8yrqLSwjuzpXuZ0oIYZ/XGgLwUIBU3uLvbcpb0pidD9ctpShJd43KSlEEkVQg6DS0G9NKyzOvBfUtDKEyHvQ==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",


### PR DESCRIPTION
Lock file was out of sync after the axios bump in #130. `npm ci` in CI failed with `lock file's axios@1.14.0 does not satisfy axios@1.15.0`. This regenerates the lock file.