### PR TITLE
Remove api_key_id and credit_id from DeepResearchBatch interface

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -555,8 +555,8 @@ export interface DeepResearchStatusResponse {
   sources?: DeepResearchSource[];
   cost?: number; // Total cost in dollars (preferred)
   usage?: DeepResearchUsage; // Detailed cost breakdown (backward compatible)
-  cost_breakdown?: DeepResearchCostBreakdown;  // Itemized cost breakdown
-  tools?: DeepResearchTools;  // Resolved tools configuration
+  cost_breakdown?: DeepResearchCostBreakdown; // Itemized cost breakdown
+  tools?: DeepResearchTools; // Resolved tools configuration
   batch_id?: string; // Batch ID if task belongs to a batch
   batch_task_id?: string; // Batch task ID if task belongs to a batch
   hitl_config?: Record<string, boolean>; // HITL configuration (mirrors request hitl param)
@@ -631,7 +631,13 @@ export interface WaitOptions {
   pollInterval?: number;
   maxWaitTime?: number;
   onProgress?: (status: DeepResearchStatusResponse) => void;
-  onInteraction?: (interaction: Interaction) => Promise<Record<string, any> | null | undefined> | Record<string, any> | null | undefined;
+  onInteraction?: (
+    interaction: Interaction,
+  ) =>
+    | Promise<Record<string, any> | null | undefined>
+    | Record<string, any>
+    | null
+    | undefined;
 }
 
 export interface StreamCallback {
@@ -667,8 +673,6 @@ export interface BatchCounts {
 export interface DeepResearchBatch {
   batch_id: string;
   organisation_id: string;
-  api_key_id: string;
-  credit_id: string;
   status: BatchStatus;
   mode: DeepResearchMode; // Renamed from 'model' in responses
   name?: string;


### PR DESCRIPTION
## Summary
- Remove `api_key_id` and `credit_id` fields from the `DeepResearchBatch` interface in `src/types.ts`
- These are internal database identifiers that were accidentally exposed in the public SDK type definition
- Severity: high - these fields should never be client-facing

---

## Task Context

| | |
|---|---|
| **Requested by** | intern-agent |
| **Run** | `a709334c` |
| **Branch** | `intern/a709334c` |

### Original Request
> Fix security vulnerability: api_key_id and credit_id fields exposed in DeepResearchBatch interface in both valyu-js and valyu-py SDKs. These are internal database identifiers that should not be client-facing.

Repo: valyu-js
File: src/types.ts:670-671
Category: secrets
Severity: high

### Attachments
None
