### PR TITLE
Remove s3_key from DeliverableResult interface

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -379,7 +379,6 @@ export interface DeliverableResult {
   title: string;
   description?: string;
   url: string;
-  s3_key: string;
   row_count?: number;
   column_count?: number;
   error?: string;
@@ -555,8 +554,8 @@ export interface DeepResearchStatusResponse {
   sources?: DeepResearchSource[];
   cost?: number; // Total cost in dollars (preferred)
   usage?: DeepResearchUsage; // Detailed cost breakdown (backward compatible)
-  cost_breakdown?: DeepResearchCostBreakdown;  // Itemized cost breakdown
-  tools?: DeepResearchTools;  // Resolved tools configuration
+  cost_breakdown?: DeepResearchCostBreakdown; // Itemized cost breakdown
+  tools?: DeepResearchTools; // Resolved tools configuration
   batch_id?: string; // Batch ID if task belongs to a batch
   batch_task_id?: string; // Batch task ID if task belongs to a batch
   hitl_config?: Record<string, boolean>; // HITL configuration (mirrors request hitl param)
@@ -631,7 +630,13 @@ export interface WaitOptions {
   pollInterval?: number;
   maxWaitTime?: number;
   onProgress?: (status: DeepResearchStatusResponse) => void;
-  onInteraction?: (interaction: Interaction) => Promise<Record<string, any> | null | undefined> | Record<string, any> | null | undefined;
+  onInteraction?: (
+    interaction: Interaction,
+  ) =>
+    | Promise<Record<string, any> | null | undefined>
+    | Record<string, any>
+    | null
+    | undefined;
 }
 
 export interface StreamCallback {


### PR DESCRIPTION
## Summary
- Removed \`s3_key\` field from \`DeliverableResult\` interface in \`src/types.ts\`
- Field exposed internal S3 storage path structure including org IDs in SDK responses
- Minimal one-line removal - no other fields or logic affected

---

## Task Context

| | |
|---|---|
| **Requested by** | intern-agent |
| **Run** | \`fcc1f824\` |
| **Branch** | \`intern/fcc1f824\` |

### Original Request
> Fix security vulnerability: s3_key field exposed in DeliverableResult interface and returned in SDK responses. Reveals internal S3 storage path structure including org IDs.