### PR TITLE
Remove s3_key from DeliverableResult public type

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -379,7 +379,6 @@ export interface DeliverableResult {
   title: string;
   description?: string;
   url: string;
-  s3_key: string;
   row_count?: number;
   column_count?: number;
   error?: string;
@@ -555,8 +554,8 @@ export interface DeepResearchStatusResponse {
   sources?: DeepResearchSource[];
   cost?: number; // Total cost in dollars (preferred)
   usage?: DeepResearchUsage; // Detailed cost breakdown (backward compatible)
-  cost_breakdown?: DeepResearchCostBreakdown;  // Itemized cost breakdown
-  tools?: DeepResearchTools;  // Resolved tools configuration
+  cost_breakdown?: DeepResearchCostBreakdown; // Itemized cost breakdown
+  tools?: DeepResearchTools; // Resolved tools configuration
   batch_id?: string; // Batch ID if task belongs to a batch
   batch_task_id?: string; // Batch task ID if task belongs to a batch
   hitl_config?: Record<string, boolean>; // HITL configuration (mirrors request hitl param)
@@ -631,7 +630,13 @@ export interface WaitOptions {
   pollInterval?: number;
   maxWaitTime?: number;
   onProgress?: (status: DeepResearchStatusResponse) => void;
-  onInteraction?: (interaction: Interaction) => Promise<Record<string, any> | null | undefined> | Record<string, any> | null | undefined;
+  onInteraction?: (
+    interaction: Interaction,
+  ) =>
+    | Promise<Record<string, any> | null | undefined>
+    | Record<string, any>
+    | null
+    | undefined;
 }
 
 export interface StreamCallback {


### PR DESCRIPTION
## Summary
- Removed `s3_key` from the public `DeliverableResult` TypeScript interface
- `s3_key` exposed internal AWS S3 storage paths (e.g. `s3://bucket/path/file.pdf`) to SDK consumers, revealing storage topology
- Field has no use in the public API surface - the `url` field already provides download access
- Minimal one-line removal; no other types or logic affected

---

## Task Context

| | |
|---|---|
| **Requested by** | intern-agent |
| **Run** | `ff19ce88` |
| **Branch** | `intern/ff19ce88` |

### Original Request
> Fix security vulnerability: Internal S3 storage path s3_key exposed in public DeliverableResult TypeScript type definition. SDK consumers receive internal infrastructure paths (e.g. s3://bucket/path/file.pdf) which reveal storage topology.

Repo: valyu-js
File: src/types.ts:382
Category: config
Severity: high

Test code (must pass after fix):
def test_KEVIN_20260401_001():
    import re
    content = open('/workspace/repos/valyu-js/src/types.ts').read()
    m = re.search(r'interface DeliverableResult\s*\{[^}]+s3_key', content, re.DOTALL)
    assert m is None, 's3_key still in DeliverableResult interface'

Apply the minimal fix to resolve this vulnerability. Run the test to confirm it passes.

### Attachments
None
