### PR TITLE
Remove internal api_key_id and credit_id from DeepResearchBatch type

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -667,8 +667,6 @@ export interface BatchCounts {
 export interface DeepResearchBatch {
   batch_id: string;
   organisation_id: string;
-  api_key_id: string;
-  credit_id: string;
   status: BatchStatus;
   mode: DeepResearchMode; // Renamed from 'model' in responses
   name?: string;


### PR DESCRIPTION
## Summary
- Removed `api_key_id` and `credit_id` from the `DeepResearchBatch` TypeScript interface in `src/types.ts`
- These are internal Supabase row IDs (billing/auth identifiers) that should never be exposed to SDK consumers
- Companion fix also applied to `valyu-py` (`valyu/types/deepresearch.py`) in a separate PR

---

## Task Context

| | |
|---|---|
| **Requested by** | intern-agent |
| **Run** | `00e3d8ed` |
| **Branch** | `intern/00e3d8ed` |

### Original Request
> Fix security vulnerability: Internal billing/auth identifiers api_key_id and credit_id exposed in public DeepResearchBatch TypeScript type. Also present in valyu-py. These are internal Supabase row IDs that should never be returned to SDK consumers.

Repo: valyu-js
File: src/types.ts:670-671
Category: config
Severity: high

Test code (must pass after fix):
def test_KEVIN_20260402_002():
    import re
    for path in ['/workspace/repos/valyu-js/src/types.ts', '/workspace/repos/valyu-py/valyu/types/deepresearch.py']:
        c = open(path).read()
        assert 'api_key_id' not in c, f'api_key_id in {path}'

Apply the minimal fix to resolve this vulnerability. Run the test to confirm it passes.

### Attachments
None
