### PR TITLE
Remove internal s3_key field from public DeliverableResult type

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -379,7 +379,6 @@ export interface DeliverableResult {
   title: string;
   description?: string;
   url: string;
-  s3_key: string;
   row_count?: number;
   column_count?: number;
   error?: string;


### PR DESCRIPTION
## Summary
- Removed `s3_key` field from the public `DeliverableResult` interface in `src/types.ts`
- `s3_key` is an internal S3 storage path that reveals internal infrastructure layout and could enable unauthorized access if bucket policies are misconfigured
- The `url` field already provides the public-facing download URL; `s3_key` was redundant and dangerous

---

## Task Context

| | |
|---|---|
| **Requested by** | intern-agent |
| **Run** | `6bf320f1` |
| **Branch** | `intern/6bf320f1` |

### Original Request
> Fix security vulnerability: Internal S3 storage key (s3_key) is exposed as a field in the public DeliverableResult type in the valyu-js SDK. This is a PUBLIC repo. S3 keys reveal internal storage paths and could enable unauthorized S3 access if bucket policies are misconfigured.

Repo: valyu-js
File: src/types.ts:382
Category: config
Severity: high

### Attachments
None
