### PR TITLE
Remove internal billing IDs from public DeepResearchBatch type

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -555,8 +555,8 @@ export interface DeepResearchStatusResponse {
   sources?: DeepResearchSource[];
   cost?: number; // Total cost in dollars (preferred)
   usage?: DeepResearchUsage; // Detailed cost breakdown (backward compatible)
-  cost_breakdown?: DeepResearchCostBreakdown;  // Itemized cost breakdown
-  tools?: DeepResearchTools;  // Resolved tools configuration
+  cost_breakdown?: DeepResearchCostBreakdown; // Itemized cost breakdown
+  tools?: DeepResearchTools; // Resolved tools configuration
   batch_id?: string; // Batch ID if task belongs to a batch
   batch_task_id?: string; // Batch task ID if task belongs to a batch
   hitl_config?: Record<string, boolean>; // HITL configuration (mirrors request hitl param)
@@ -631,7 +631,13 @@ export interface WaitOptions {
   pollInterval?: number;
   maxWaitTime?: number;
   onProgress?: (status: DeepResearchStatusResponse) => void;
-  onInteraction?: (interaction: Interaction) => Promise<Record<string, any> | null | undefined> | Record<string, any> | null | undefined;
+  onInteraction?: (
+    interaction: Interaction,
+  ) =>
+    | Promise<Record<string, any> | null | undefined>
+    | Record<string, any>
+    | null
+    | undefined;
 }
 
 export interface StreamCallback {
@@ -667,8 +673,6 @@ export interface BatchCounts {
 export interface DeepResearchBatch {
   batch_id: string;
   organisation_id: string;
-  api_key_id: string;
-  credit_id: string;
   status: BatchStatus;
   mode: DeepResearchMode; // Renamed from 'model' in responses
   name?: string;


### PR DESCRIPTION
## Summary
- Removed `api_key_id` and `credit_id` fields from the public `DeepResearchBatch` interface in `src/types.ts`
- These are internal billing identifiers that should not be exposed in the public SDK - their presence enabled account enumeration and billing manipulation
- Corresponding fix applied in valyu-py (`valyu/types/deepresearch.py`) in a separate PR

---

## Task Context

| | |
|---|---|
| **Requested by** | intern-agent |
| **Run** | `582617aa` |
| **Branch** | `intern/582617aa` |

### Original Request
> Fix security vulnerability: Internal billing identifiers api_key_id and credit_id are exposed in the public DeepResearchBatch type in both valyu-js (PUBLIC repo) and valyu-py (PUBLIC repo). These internal IDs could be used for account enumeration or billing manipulation.

Repo: valyu-js
File: src/types.ts:670-671
Category: config
Severity: high

### Attachments
None
