### PR TITLE
Fix Deep Research ChartType drift (radar/heatmap/etc.)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "valyu-js",
-  "version": "2.7.12",
+  "version": "2.7.13",
   "description": "Deepsearch API for AI.",
   "files": [
     "dist"

--- a/src/types.ts
+++ b/src/types.ts
@@ -337,7 +337,23 @@ export type DeepResearchOutputFormat =
   | Record<string, any>;
 export type DeepResearchOutputType = "markdown" | "json" | "toon";
 export type ImageType = "chart" | "ai_generated" | "screenshot";
-export type ChartType = "line" | "bar" | "area";
+export type ChartType =
+  | "line"
+  | "bar"
+  | "area"
+  | "pie"
+  | "doughnut"
+  | "radar"
+  | "scatter"
+  | "horizontalBar"
+  | "heatmap"
+  | "boxplot"
+  | "stackedBar"
+  | "stackedArea"
+  | "histogram"
+  | "waterfall"
+  | "timeline"
+  | "bubble";
 
 export interface FileAttachment {
   data: string;
@@ -467,11 +483,15 @@ export interface Progress {
 export interface ChartDataPoint {
   x: string | number;
   y: number;
+  y2?: number;
+  z?: number;
+  values?: number[];
 }
 
 export interface ChartDataSeries {
   name: string;
   data: ChartDataPoint[];
+  line_style?: "solid" | "dashed" | "dotted";
 }
 
 export interface ImageMetadata {


### PR DESCRIPTION
## Summary

The Deep Research server emits 16 chart types, but the JS SDK's \`ChartType\` union only allowed \`line | bar | area\`. Consumers using the typed responses get TS errors and runtime payloads carry chart types the type system says cannot exist (Python SDK with the same drift hard-fails on Pydantic validation).

This PR brings the SDK to parity with the server in \`infrastructure/servers/deepresearch/src/types.ts\`:

- \`ChartType\`: add \`pie, doughnut, radar, scatter, horizontalBar, heatmap, boxplot, stackedBar, stackedArea, histogram, waterfall, timeline, bubble\`
- \`ChartDataPoint\`: add optional \`y2\` (timeline end), \`z\` (bubble size), \`values\` (boxplot raw data)
- \`ChartDataSeries\`: add optional \`line_style\` (\`"solid" | "dashed" | "dotted"\`)
- Bump \`2.7.12 -> 2.7.13\`

All additions are optional / additive — backwards compatible.

## Test plan

- [ ] \`npm run build\` succeeds
- [ ] CI passes