### PR TITLE
Add charts flag to DeepResearchTools

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "valyu-js",
-  "version": "2.7.12",
+  "version": "2.7.14",
   "description": "Deepsearch API for AI.",
   "files": [
     "dist"

--- a/src/types.ts
+++ b/src/types.ts
@@ -400,6 +400,8 @@ export interface DeepResearchSearchConfig {
 export interface DeepResearchTools {
   code_execution?: boolean;
   screenshots?: boolean;
+  /** Enable chart/graph generation embedded in the final report (free) */
+  charts?: boolean;
 }
 
 export interface DeepResearchCreateOptions {


### PR DESCRIPTION
## Summary

Adds the new `charts` opt-in to `DeepResearchTools`, mirroring an upcoming server-side change that makes chart generation a toggleable Deep Research tool.

```ts
const tools: DeepResearchTools = {
  code_execution: false,
  screenshots: false,
  charts: true,
};
```

- Free — no per-call surcharge
- Default `false` to match the server default

Bumps `2.7.12 -> 2.7.14`. Skipping `2.7.13` because that version was reserved for the in-flight chart-types parity PR (#138); whichever merged first owned its bump number.

## Test plan

- [ ] `npm run build` succeeds
- [ ] Server change merged before publishing this version (otherwise the field is silently dropped by the API)