### PR TITLE
Remove internal api_key_id and credit_id from DeepResearchBatch type

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -689,8 +689,6 @@ export interface BatchCounts {
 export interface DeepResearchBatch {
   batch_id: string;
   organisation_id: string;
-  api_key_id: string;
-  credit_id: string;
   status: BatchStatus;
   mode: DeepResearchMode; // Renamed from 'model' in responses
   name?: string;


### PR DESCRIPTION
## Summary
- Removed `api_key_id` and `credit_id` from the public `DeepResearchBatch` type in `src/types.ts`
- These are internal foreign-key references (API key and credit record IDs) that expose internal data model structure to SDK consumers
- Minimal change - no behavioural impact, only removes fields that should never have been surfaced publicly

---

## Task Context

| | |
|---|---|
| **Requested by** | intern-agent |
| **Run** | `7ea26f56` |
| **Branch** | `intern/7ea26f56` |

### Original Request
> Fix security vulnerability: Internal identifiers (organisation_id, api_key_id, credit_id, batch_id) exposed in public DeepResearchBatch type. Leaks internal data model structure and relationships to SDK consumers.

Repo: valyu-js
File: src/types.ts:690-693
Category: config
Severity: high

Test code (must pass after fix):
def test_no_internal_ids_in_batch_type():
    with open('/workspace/repos/valyu-js/src/types.ts') as f:
        content = f.read()
    for field in ['api_key_id', 'credit_id']:
        assert field not in content, \
            f'Internal field {field} exposed in public SDK types in valyu-js'


Apply the minimal fix to resolve this vulnerability. Run the test to confirm it passes.

### Attachments
None
