### PR TITLE
Add optional fragment field to DeepResearchSource

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "valyu-js",
-  "version": "2.7.14",
+  "version": "2.7.15",
   "description": "Deepsearch API for AI.",
   "files": [
     "dist"

--- a/src/types.ts
+++ b/src/types.ts
@@ -526,6 +526,7 @@ export interface DeepResearchSource {
   category?: string;
   source_id?: number;
   word_count?: number;
+  fragment?: string;
 }
 
 export interface DeepResearchUsage {


### PR DESCRIPTION
## Summary

- Adds optional `fragment?: string` to the `DeepResearchSource` interface.
- Bumps version to `2.7.15` (patch).

## Field

`fragment` is an optional URL fragment that, when appended to `url`, produces a deep-link to the cited passage on the source page (Scroll-to-Text-Fragment for HTML, PDF Open Parameters for PDF). Field is omitted when no reliable highlight target is available — clients fall back to the canonical `url`.

Purely additive — no breaking change. Existing consumers ignore the field.

## Test plan

- [ ] `npm run build` succeeds
- [ ] Generated `.d.ts` includes `fragment?: string` on `DeepResearchSource`
- [ ] Confirm a Deep Research response with no `fragment` still type-checks
- [ ] Confirm a response containing `fragment` populates the field