### PR TITLE
Remove internal s3_key and api_key_id fields from public SDK types

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -395,7 +395,6 @@ export interface DeliverableResult {
   title: string;
   description?: string;
   url: string;
-  s3_key: string;
   row_count?: number;
   column_count?: number;
   error?: string;
@@ -577,8 +576,8 @@ export interface DeepResearchStatusResponse {
   sources?: DeepResearchSource[];
   cost?: number; // Total cost in dollars (preferred)
   usage?: DeepResearchUsage; // Detailed cost breakdown (backward compatible)
-  cost_breakdown?: DeepResearchCostBreakdown;  // Itemized cost breakdown
-  tools?: DeepResearchTools;  // Resolved tools configuration
+  cost_breakdown?: DeepResearchCostBreakdown; // Itemized cost breakdown
+  tools?: DeepResearchTools; // Resolved tools configuration
   batch_id?: string; // Batch ID if task belongs to a batch
   batch_task_id?: string; // Batch task ID if task belongs to a batch
   hitl_config?: Record<string, boolean>; // HITL configuration (mirrors request hitl param)
@@ -653,7 +652,13 @@ export interface WaitOptions {
   pollInterval?: number;
   maxWaitTime?: number;
   onProgress?: (status: DeepResearchStatusResponse) => void;
-  onInteraction?: (interaction: Interaction) => Promise<Record<string, any> | null | undefined> | Record<string, any> | null | undefined;
+  onInteraction?: (
+    interaction: Interaction,
+  ) =>
+    | Promise<Record<string, any> | null | undefined>
+    | Record<string, any>
+    | null
+    | undefined;
 }
 
 export interface StreamCallback {
@@ -689,7 +694,6 @@ export interface BatchCounts {
 export interface DeepResearchBatch {
   batch_id: string;
   organisation_id: string;
-  api_key_id: string;
   credit_id: string;
   status: BatchStatus;
   mode: DeepResearchMode; // Renamed from 'model' in responses


### PR DESCRIPTION
## Summary
- Remove `s3_key` from `DeliverableResult` interface - exposes internal S3 storage key naming to SDK consumers
- Remove `api_key_id` from `DeepResearchBatch` interface - exposes internal API key table schema to SDK consumers
- Both fields are internal infrastructure details with no use to external SDK consumers

---

## Task Context

| | |
|---|---|
| **Requested by** | intern-agent |
| **Run** | `4adfd78b` |
| **Branch** | `intern/4adfd78b` |

### Original Request
> Fix security vulnerability: Internal S3 key and api_key_id field names exposed in public SDK TypeScript type definitions, leaking internal architecture details.

Repo: valyu-js
File: src/types.ts
Category: config
Severity: high

Test code (must pass after fix):
test_sdk_api_parity.py::test_kevin_20260401_001_js_internal_types

Apply the minimal fix to resolve this vulnerability. Run the test to confirm it passes.

### Attachments
None
