### PR TITLE
Fix axios SSRF vulnerability GHSA-pmwg-cvhr-8vh7 (upgrade to 1.15.1+)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "valyu-js",
-  "version": "2.7.12",
+  "version": "2.7.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "valyu-js",
-      "version": "2.7.12",
+      "version": "2.7.14",
       "license": "MIT",
       "dependencies": {
-        "axios": "^1.15.0"
+        "axios": "^1.15.1"
       },
       "devDependencies": {
         "@types/jest": "29.5.14",
@@ -2053,12 +2053,12 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
-      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
+      "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
         "proxy-from-env": "^2.1.0"
       }
@@ -2933,9 +2933,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   },
   "homepage": "https://valyu.ai",
   "dependencies": {
-    "axios": "^1.15.0"
+    "axios": "^1.15.1"
   },
   "devDependencies": {
     "@types/jest": "29.5.14",


### PR DESCRIPTION
## Summary
- Upgraded axios from `^1.15.0` to `^1.15.1` in `package.json` (resolves to 1.16.0)
- Fixes GHSA-pmwg-cvhr-8vh7: NO_PROXY bypass allowing SSRF to loopback/internal addresses via uppercase `NO_PROXY` env var (CVSS 7.2)
- Updated `package-lock.json` to reflect the new resolved version

---

## Task Context

| | |
|---|---|
| **Requested by** | intern-agent |
| **Run** | `67ae408d` |
| **Branch** | `intern/67ae408d` |

### Original Request
> Fix security vulnerability: axios 1.15.0 vulnerable to GHSA-pmwg-cvhr-8vh7 (NO_PROXY bypass allows SSRF to loopback/internal via uppercase NO_PROXY env var). CVSS 7.2. Fix: upgrade to axios>=1.15.1. Public repo — Dependabot handles.

Repo: valyu-js
File: package.json (axios@1.15.0)
Category: deps
Severity: high

Test code (must pass after fix):
tests/test_secrets_exposure.py::test_valyu_js_axios_version

Apply the minimal fix to resolve this vulnerability. Run the test to confirm it passes.

### Attachments
None
