### PR TITLE
Add per-tool max_calls override and browser_use tool

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "valyu-js",
-  "version": "2.7.12",
+  "version": "2.7.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "valyu-js",
-      "version": "2.7.12",
+      "version": "2.7.16",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.15.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "valyu-js",
-  "version": "2.7.15",
+  "version": "2.7.16",
   "description": "Deepsearch API for AI.",
   "files": [
     "dist"

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,7 +47,7 @@ import {
   DatasourcesCategoriesResponse,
 } from "./types";
 
-const SDK_VERSION = "2.7.12";
+const SDK_VERSION = "2.7.16";
 
 /** Normalize API job response (snake_case) to SDK format (camelCase). */
 function normalizeContentsJobResponse(api: Record<string, any>): ContentsJobResponse {
@@ -2233,6 +2233,7 @@ export type {
   DeepResearchSource,
   DeepResearchUsage,
   DeepResearchCostBreakdown,
+  ToolConfig,
   DeepResearchTools,
   DeepResearchCreateResponse,
   DeepResearchStatusResponse,

--- a/src/types.ts
+++ b/src/types.ts
@@ -413,9 +413,21 @@ export interface DeepResearchSearchConfig {
   countryCode?: CountryCode; // Country code for location-filtered searches
 }
 
+/**
+ * Per-tool configuration with optional call limit.
+ *
+ * max_calls can only be lowered, not raised above the system default.
+ * Setting max_calls to 0 effectively disables the tool.
+ */
+export interface ToolConfig {
+  enabled?: boolean;
+  max_calls?: number;
+}
+
 export interface DeepResearchTools {
-  code_execution?: boolean;
-  screenshots?: boolean;
+  code_execution?: boolean | ToolConfig;
+  screenshots?: boolean | ToolConfig;
+  browser_use?: boolean | ToolConfig;
   /** Enable chart/graph generation embedded in the final report (free) */
   charts?: boolean;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -428,8 +428,8 @@ export interface DeepResearchTools {
   code_execution?: boolean | ToolConfig;
   screenshots?: boolean | ToolConfig;
   browser_use?: boolean | ToolConfig;
-  /** Enable chart/graph generation embedded in the final report (free) */
-  charts?: boolean;
+  /** Enable chart/graph generation embedded in the final report (free, unlimited) */
+  charts?: boolean | ToolConfig;
 }
 
 export interface DeepResearchCreateOptions {


### PR DESCRIPTION
## Summary

- Add `ToolConfig` interface with `enabled` and `max_calls` fields
- Update `DeepResearchTools` so each tool (`code_execution`, `screenshots`, new `browser_use`) accepts `boolean | ToolConfig`
- `max_calls` lets users cap per-tool invocations to manage cost (capped at system defaults: browser_use=5, screenshots=15, code_execution=10)
- Export `ToolConfig` from index
- Sync `SDK_VERSION` constant to package version
- Bump version 2.7.15 → 2.7.16

Brings valyu-js to parity with the equivalent valyu-py PR.

## Test plan

- [ ] \`npm run build\` succeeds (verified locally)
- [ ] Generated \`dist/index.d.ts\` shows \`ToolConfig\` and \`browser_use\` (verified locally)
- [ ] Verify \`DeepResearchTools\` accepts both boolean and object formats
- [ ] Verify backward compatibility with existing \`tools: { code_execution: true }\` calls