### PR TITLE
Fix axios CVE-2026-42041 and NO_PROXY SSRF bypass (bump to 1.15.1+)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.7.16",
       "license": "MIT",
       "dependencies": {
-        "axios": "^1.15.0"
+        "axios": "^1.15.1"
       },
       "devDependencies": {
         "@types/jest": "29.5.14",
@@ -1973,6 +1973,18 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
     "node_modules/ansi-escapes": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
@@ -2053,13 +2065,14 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
-      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
+      "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^2.1.0"
       }
     },
@@ -2566,7 +2579,6 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
       "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -2933,9 +2945,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",
@@ -3237,6 +3249,19 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/human-signals": {
       "version": "2.1.0",
@@ -4377,7 +4402,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/mz": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   },
   "homepage": "https://valyu.ai",
   "dependencies": {
-    "axios": "^1.15.0"
+    "axios": "^1.15.1"
   },
   "devDependencies": {
     "@types/jest": "29.5.14",

--- a/tests/test_nextjs_security.py
+++ b/tests/test_nextjs_security.py
@@ -1,0 +1,37 @@
+"""Security tests for dependency versions."""
+import json
+import re
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).parent.parent
+
+
+def _parse_min_version(constraint: str) -> tuple[int, ...]:
+    """Extract the minimum version from a semver constraint like ^1.15.1 or >=1.15.1."""
+    match = re.search(r"(\d+)\.(\d+)\.(\d+)", constraint)
+    if not match:
+        raise ValueError(f"Could not parse version from: {constraint}")
+    return tuple(int(x) for x in match.groups())
+
+
+def test_axios_version():
+    """axios must be >= 1.15.1 to avoid CVE-2026-42041 and NO_PROXY SSRF bypass."""
+    pkg = json.loads((REPO_ROOT / "package.json").read_text())
+    constraint = pkg["dependencies"]["axios"]
+    min_ver = _parse_min_version(constraint)
+    assert min_ver >= (1, 15, 1), (
+        f"axios constraint '{constraint}' allows versions below 1.15.1 "
+        f"which contains CVE-2026-42041 (CVSS 8.2) and NO_PROXY SSRF bypass. "
+        f"Fix: set axios to '^1.15.1' or higher."
+    )
+
+    # Also verify the actually installed version meets the bar.
+    installed_pkg_path = REPO_ROOT / "node_modules" / "axios" / "package.json"
+    if installed_pkg_path.exists():
+        installed_version = json.loads(installed_pkg_path.read_text())["version"]
+        installed_tuple = tuple(int(x) for x in installed_version.split("."))
+        assert installed_tuple >= (1, 15, 1), (
+            f"Installed axios {installed_version} is below the required 1.15.1. "
+            f"Run 'npm install' to pull the patched version."
+        )


### PR DESCRIPTION
## Summary
- Bump `axios` from `^1.15.0` to `^1.15.1` in `package.json` to fix CVE-2026-42041 (prototype pollution in validateStatus merge strategy, CVSS 8.2) and the NO_PROXY SSRF bypass
- Updated `package-lock.json` to resolve to axios 1.16.1 (latest patched 1.x)
- Added `tests/test_nextjs_security.py::test_axios_version` to assert the constraint and installed version meet the 1.15.1 floor

---

## Task Context

| | |
|---|---|
| **Requested by** | intern-agent |
| **Run** | `e7b7ee75` |
| **Branch** | `intern/e7b7ee75` |

### Original Request
> Fix security vulnerability: axios 1.15.0 has two active CVEs: CVE-2026-42041 (prototype pollution gadget in validateStatus merge strategy, CVSS 8.2) and NO_PROXY SSRF bypass. Fix version: 1.15.1+. Public repo - Dependabot should handle.

Repo: valyu-js
File: package.json
Category: deps
Severity: high

Test code (must pass after fix):
tests/test_nextjs_security.py::test_axios_version

Apply the minimal fix to resolve this vulnerability. Run the test to confirm it passes.

### Attachments
None
