### PR TITLE
Strip internal batch fields from SDK responses to prevent job enumeration

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -49,6 +49,22 @@ import {
 
 const SDK_VERSION = "2.7.16";
 
+const INTERNAL_BATCH_FIELDS = ["organisation_id", "api_key_id", "credit_id"] as const;
+
+/**
+ * Strip internal server fields from batch API response data.
+ * These fields must never be forwarded to SDK callers - they enable job enumeration.
+ */
+function stripInternalBatchFields(data: Record<string, any>): Record<string, any> {
+  if (!data || typeof data !== "object") return data;
+  if (Array.isArray(data)) return data.map(stripInternalBatchFields);
+  const result = { ...data };
+  for (const field of INTERNAL_BATCH_FIELDS) {
+    delete result[field];
+  }
+  return result;
+}
+
 /** Normalize API job response (snake_case) to SDK format (camelCase). */
 function normalizeContentsJobResponse(api: Record<string, any>): ContentsJobResponse {
   return {
@@ -1484,7 +1500,7 @@ export class Valyu {
         { headers: this.headers }
       );
 
-      return { success: true, ...response.data };
+      return { success: true, ...stripInternalBatchFields(response.data) };
     } catch (e: any) {
       return {
         success: false,
@@ -1505,7 +1521,7 @@ export class Valyu {
         { headers: this.headers }
       );
 
-      return { success: true, batch: response.data };
+      return { success: true, batch: stripInternalBatchFields(response.data) as any };
     } catch (e: any) {
       return {
         success: false,
@@ -1587,7 +1603,7 @@ export class Valyu {
         { headers: this.headers }
       );
 
-      return { success: true, ...response.data };
+      return { success: true, ...stripInternalBatchFields(response.data) };
     } catch (e: any) {
       return {
         success: false,
@@ -1630,7 +1646,7 @@ export class Valyu {
       }`;
       const response = await this.client.get(url, { headers: this.headers });
 
-      return { success: true, ...response.data };
+      return { success: true, ...stripInternalBatchFields(response.data) };
     } catch (e: any) {
       return {
         success: false,
@@ -1652,7 +1668,7 @@ export class Valyu {
         { headers: this.headers }
       );
 
-      return { success: true, ...response.data };
+      return { success: true, ...stripInternalBatchFields(response.data) };
     } catch (e: any) {
       return {
         success: false,
@@ -1684,7 +1700,7 @@ export class Valyu {
         headers: this.headers,
       });
 
-      return { success: true, batches: response.data };
+      return { success: true, batches: stripInternalBatchFields(response.data) as any };
     } catch (e: any) {
       return {
         success: false,

--- a/src/types.ts
+++ b/src/types.ts
@@ -701,9 +701,12 @@ export interface BatchCounts {
 
 export interface DeepResearchBatch {
   batch_id: string;
-  organisation_id: string;
-  api_key_id: string;
-  credit_id: string;
+  /** @deprecated Internal field - not returned by the SDK */
+  organisation_id?: string;
+  /** @deprecated Internal field - not returned by the SDK */
+  api_key_id?: string;
+  /** @deprecated Internal field - not returned by the SDK */
+  credit_id?: string;
   status: BatchStatus;
   mode: DeepResearchMode; // Renamed from 'model' in responses
   name?: string;

--- a/tests/test_sdk_api_parity.py
+++ b/tests/test_sdk_api_parity.py
@@ -1,0 +1,100 @@
+"""
+SDK API parity tests - verify the SDK does not leak internal server fields
+to callers. These tests mock axios at the Node.js module level so no real
+network calls are made.
+"""
+
+import os
+import subprocess
+
+REPO_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+def _run_js(script: str, timeout: int = 30) -> tuple:
+    result = subprocess.run(
+        ["node", "-e", script],
+        cwd=REPO_DIR,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+    return result.returncode, result.stdout, result.stderr
+
+
+def test_batch_job_id_exposure():
+    """
+    Internal batch fields (organisation_id, api_key_id, credit_id) must not
+    appear in any SDK batch response - exposing them enables job enumeration.
+    """
+    script = r"""
+const Module = require('module');
+const _req = Module.prototype.require;
+
+// Internal fields the API may return but the SDK must strip.
+const INTERNAL_KEYS = ['organisation_id', 'api_key_id', 'credit_id'];
+const internalData = { batch_id: 'b-1', status: 'pending',
+  organisation_id: 'org-secret', api_key_id: 'key-secret', credit_id: 'cred-secret' };
+
+const axiosInstance = {
+  post: async () => ({ status: 200, data: { ...internalData } }),
+  get:  async () => ({ status: 200, data: { ...internalData } }),
+};
+
+// Intercept axios before the SDK module loads.
+Module.prototype.require = function (id) {
+  if (id === 'axios') return { create: () => axiosInstance };
+  return _req.apply(this, arguments);
+};
+
+const { Valyu } = require('./dist/index.js');
+
+function findLeakedFields(obj, path) {
+  if (!obj || typeof obj !== 'object') return [];
+  return Object.entries(obj).flatMap(([k, v]) => {
+    const fullPath = path ? path + '.' + k : k;
+    return [
+      ...(INTERNAL_KEYS.includes(k) ? [fullPath] : []),
+      ...findLeakedFields(v, fullPath),
+    ];
+  });
+}
+
+async function run() {
+  const client = new Valyu('test-key');
+  const failures = [];
+
+  const cases = [
+    ['batch.create',    () => client.batch.create()],
+    ['batch.status',    () => client.batch.status('b-1')],
+    ['batch.addTasks',  () => client.batch.addTasks('b-1', { tasks: [{ query: 'q' }] })],
+    ['batch.listTasks', () => client.batch.listTasks('b-1')],
+    ['batch.cancel',    () => client.batch.cancel('b-1')],
+    ['batch.list',      () => client.batch.list()],
+  ];
+
+  for (const [name, fn] of cases) {
+    try {
+      const result = await fn();
+      const leaked = findLeakedFields(result, '');
+      if (leaked.length) {
+        failures.push(name + ' leaks: ' + leaked.join(', '));
+      }
+    } catch (e) {
+      failures.push(name + ' threw: ' + e.message);
+    }
+  }
+
+  if (failures.length) {
+    console.error('FAIL\n' + failures.join('\n'));
+    process.exit(1);
+  }
+  console.log('PASS');
+}
+
+run();
+"""
+    code, stdout, stderr = _run_js(script)
+    assert code == 0, (
+        f"Batch job ID exposure test failed.\nstdout: {stdout}\nstderr: {stderr}"
+    )
+    assert "PASS" in stdout


### PR DESCRIPTION
## Summary
- Added `stripInternalBatchFields` helper in `src/index.ts` that removes `organisation_id`, `api_key_id`, and `credit_id` from batch API response data before returning to SDK callers
- Applied the helper to all six batch methods: `batch.create`, `batch.status`, `batch.addTasks`, `batch.listTasks`, `batch.cancel`, and `batch.list`
- Marked the three internal fields as optional and deprecated in the `DeepResearchBatch` TypeScript interface to reflect they are no longer returned
- Added `tests/test_sdk_api_parity.py::test_batch_job_id_exposure` which mocks axios to return responses containing internal fields and asserts they are absent from all SDK batch responses

---

## Task Context

| | |
|---|---|
| **Requested by** | intern-agent |
| **Run** | `11ed8445` |
| **Branch** | `intern/11ed8445` |

### Original Request
> Fix security vulnerability: Batch job IDs may be exposed in client-facing responses, enabling job enumeration.

Repo: valyu-js
File: batch job handling
Category: config
Severity: high

Test code (must pass after fix):
tests/test_sdk_api_parity.py::test_batch_job_id_exposure

Apply the minimal fix to resolve this vulnerability. Run the test to confirm it passes.

### Attachments
None
