### PR TITLE
Fix CVE-2026-42041: upgrade axios to 1.16.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.7.16",
       "license": "MIT",
       "dependencies": {
-        "axios": "^1.15.0"
+        "axios": "^1.16.1"
       },
       "devDependencies": {
         "@types/jest": "29.5.14",
@@ -1973,6 +1973,18 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
     "node_modules/ansi-escapes": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
@@ -2053,13 +2065,14 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
-      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
+      "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^2.1.0"
       }
     },
@@ -2566,7 +2579,6 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
       "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -2933,9 +2945,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",
@@ -3237,6 +3249,19 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/human-signals": {
       "version": "2.1.0",
@@ -4377,7 +4402,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/mz": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   },
   "homepage": "https://valyu.ai",
   "dependencies": {
-    "axios": "^1.15.0"
+    "axios": "^1.16.1"
   },
   "devDependencies": {
     "@types/jest": "29.5.14",

--- a/tests/test_key_exposure.py
+++ b/tests/test_key_exposure.py
@@ -1,0 +1,35 @@
+"""
+Security tests for dependency vulnerabilities in valyu-js.
+"""
+import json
+import os
+import unittest
+
+
+class TestAxiosVulnerability(unittest.TestCase):
+    def _get_axios_version(self) -> str:
+        """Read the locked axios version from package-lock.json."""
+        lock_path = os.path.join(os.path.dirname(__file__), "..", "package-lock.json")
+        with open(lock_path) as f:
+            data = json.load(f)
+        return data["packages"]["node_modules/axios"]["version"]
+
+    def test_KEVIN_20260507_001_axios_version(self):
+        """
+        CVE-2026-42041: Axios 1.15.0 prototype pollution gadget in
+        validateStatus merge strategy (CVSS 8.2, authentication bypass).
+        Fixed in 1.15.1+.
+        """
+        axios_version = self._get_axios_version()
+        parts = tuple(int(x) for x in axios_version.split("."))
+        self.assertGreater(
+            parts,
+            (1, 15, 0),
+            f"axios {axios_version} is vulnerable to CVE-2026-42041 "
+            "(prototype pollution in validateStatus merge strategy, CVSS 8.2). "
+            "Upgrade to 1.15.1 or later.",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Upgraded axios from 1.15.0 to 1.16.1 in `package.json` and `package-lock.json`
- Resolves CVE-2026-42041: prototype pollution gadget in `validateStatus` merge strategy (CVSS 8.2) that could allow authentication bypass
- Added `tests/test_key_exposure.py` with `TestAxiosVulnerability::test_KEVIN_20260507_001_axios_version` to verify the safe version is locked

---

## Task Context

| | |
|---|---|
| **Requested by** | intern-agent |
| **Run** | `f53fb6d0` |
| **Branch** | `intern/f53fb6d0` |

### Original Request
> Fix security vulnerability: Axios 1.15.0 is vulnerable to CVE-2026-42041 (prototype pollution gadget in validateStatus merge strategy, CVSS 8.2). Allows authentication bypass if Object.prototype is polluted elsewhere in the dependency chain.

Repo: valyu-js
File: package.json (axios 1.15.0)
Category: deps
Severity: high

Test code (must pass after fix):
tests/test_key_exposure.py::TestAxiosVulnerability::test_KEVIN_20260507_001_axios_version

Apply the minimal fix to resolve this vulnerability. Run the test to confirm it passes.

### Attachments
None
