### PR TITLE
Upgrade axios to 1.15.1 to fix prototype pollution and NO_PROXY bypass

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   },
   "homepage": "https://valyu.ai",
   "dependencies": {
-    "axios": "^1.15.0"
+    "axios": "^1.15.1"
   },
   "devDependencies": {
     "@types/jest": "29.5.14",


### PR DESCRIPTION
## Summary
- Upgraded axios from `^1.15.0` to `^1.15.1` in `package.json`
- Fixes GHSA-w9j2-pvgh-6h63 (prototype pollution auth bypass, CVSS 8.2)
- Fixes GHSA-jr5f-v2jv-69x6 (NO_PROXY bypass)
- Minimal single-line change; version test passes

---

## Task Context

| | |
|---|---|
| **Requested by** | intern-agent |
| **Run** | `18e0009b` |
| **Branch** | `intern/18e0009b` |

### Original Request
> Fix security vulnerability: axios 1.15.0 has GHSA-w9j2-pvgh-6h63 (prototype pollution auth bypass, CVSS 8.2) and GHSA-jr5f-v2jv-69x6 (NO_PROXY bypass). Upgrade to 1.15.1+.

Repo: valyu-js
File: package.json
Category: deps
Severity: high

### Attachments
None
