### PR TITLE
Upgrade axios to 1.15.1 to fix CVE-2026-42041

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   },
   "homepage": "https://valyu.ai",
   "dependencies": {
-    "axios": "^1.15.0"
+    "axios": "^1.15.1"
   },
   "devDependencies": {
     "@types/jest": "29.5.14",


### PR DESCRIPTION
## Summary
- Upgraded axios from `^1.15.0` to `^1.15.1` in package.json
- Fixes CVE-2026-42041 (GHSA-w9j2-pvgh-6h63): prototype pollution gadget in validateStatus merge strategy allowed 401/403/500 responses to be treated as success
- CVSS 8.2 high severity - minimal one-line change, no API impact

---

## Task Context

| | |
|---|---|
| **Requested by** | intern-agent |
| **Run** | `f32856d8` |
| **Branch** | `intern/f32856d8` |

### Original Request
> Fix security vulnerability: axios 1.15.0 is vulnerable to CVE-2026-42041 (GHSA-w9j2-pvgh-6h63): prototype pollution gadget in validateStatus merge strategy allows bypassing HTTP error handling — 401/403/500 responses treated as success. CVSS 8.2. Fix: upgrade to 1.15.1+. 8 scans open.

Repo: valyu-js
File: package.json
Category: deps
Severity: high

Test code (must pass after fix):
import json

def test_axios_version_not_vulnerable():
    with open('/workspace/repos/valyu-js/package.json') as f:
        pkg = json.load(f)
    dep_version = pkg.get('dependencies', {}).get('axios', '')
    assert dep_version, 'axios dependency not found'
    # Remove ^ or ~ prefix
    version = dep_version.lstrip('^~>=<')
    major, minor, patch = [int(x) for x in version.split('.')[:3]]
    assert (major, minor, patch) >= (1, 15, 1), f'axios {version} is vulnerable to CVE-2026-42041, upgrade to 1.15.1+'

Apply the minimal fix to resolve this vulnerability. Run the test to confirm it passes.

### Attachments
None
