### PR TITLE
Fix CVE-2026-42041: upgrade axios 1.15.0 to 1.16.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.7.16",
       "license": "MIT",
       "dependencies": {
-        "axios": "^1.15.0"
+        "axios": "^1.16.1"
       },
       "devDependencies": {
         "@types/jest": "29.5.14",
@@ -1973,6 +1973,18 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
     "node_modules/ansi-escapes": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
@@ -2053,13 +2065,14 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
-      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
+      "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^2.1.0"
       }
     },
@@ -2566,7 +2579,6 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
       "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -2933,9 +2945,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",
@@ -3237,6 +3249,19 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/human-signals": {
       "version": "2.1.0",
@@ -4377,7 +4402,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/mz": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   },
   "homepage": "https://valyu.ai",
   "dependencies": {
-    "axios": "^1.15.0"
+    "axios": "^1.16.1"
   },
   "devDependencies": {
     "@types/jest": "29.5.14",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1413,7 +1413,7 @@ export class Valyu {
         success: true,
         data: Buffer.from(response.data),
         contentType:
-          response.headers["content-type"] || "application/octet-stream",
+          String(response.headers["content-type"] || "application/octet-stream"),
       };
     } catch (e: any) {
       return {

--- a/tests/test_hardcoded_keys.py
+++ b/tests/test_hardcoded_keys.py
@@ -1,0 +1,75 @@
+"""
+Security test: verify no hardcoded API keys in source files and
+that axios is not pinned to the vulnerable CVE-2026-42041 version.
+"""
+import json
+import os
+import re
+
+import pytest
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+# Patterns that indicate hardcoded credentials
+_HARDCODED_KEY_PATTERNS = [
+    # api_key / apikey assignment to a quoted string of >= 16 chars
+    r'(?i)(?:api[_\-\s]?key|apikey)\s*[=:]\s*["\'][A-Za-z0-9_\-]{16,}["\']',
+    # Bearer token literal
+    r'(?i)bearer\s+[A-Za-z0-9_\-\.]{20,}',
+    # Valyu-specific key prefix
+    r'["\']val_[A-Za-z0-9]{20,}["\']',
+    # secret / token / password assignment to a quoted string
+    r'(?i)(?:secret|token|password|passwd|pwd)\s*[=:]\s*["\'][A-Za-z0-9_\-]{16,}["\']',
+]
+
+_SOURCE_EXTENSIONS = {".ts", ".js", ".mjs", ".cjs"}
+_EXCLUDE_DIRS = {"node_modules", "dist", ".git", "__pycache__", ".github"}
+
+
+def _source_files():
+    for root, dirs, filenames in os.walk(REPO_ROOT):
+        dirs[:] = [d for d in dirs if d not in _EXCLUDE_DIRS]
+        for name in filenames:
+            if os.path.splitext(name)[1] in _SOURCE_EXTENSIONS:
+                yield os.path.join(root, name)
+
+
+def test_no_hardcoded_api_keys():
+    """Source files must not contain hardcoded API keys or secrets."""
+    violations = []
+    for filepath in _source_files():
+        try:
+            with open(filepath, encoding="utf-8", errors="ignore") as fh:
+                content = fh.read()
+        except OSError:
+            continue
+        for pattern in _HARDCODED_KEY_PATTERNS:
+            if re.search(pattern, content):
+                rel = os.path.relpath(filepath, REPO_ROOT)
+                violations.append(f"{rel}: matched /{pattern}/")
+    assert not violations, "Hardcoded credentials found:\n" + "\n".join(violations)
+
+
+def test_axios_not_vulnerable():
+    """axios must not be the CVE-2026-42041-vulnerable version 1.15.0."""
+    pkg_path = os.path.join(REPO_ROOT, "package.json")
+    with open(pkg_path) as fh:
+        pkg = json.load(fh)
+
+    spec = pkg.get("dependencies", {}).get("axios", "")
+    # Strip range operators to get the bare version
+    bare = spec.lstrip("^~>=< ").strip()
+
+    assert bare != "1.15.0", (
+        f"axios is pinned to {bare} which is vulnerable to CVE-2026-42041 "
+        "(prototype pollution in validateStatus merge strategy). "
+        "Update to >= 1.15.1."
+    )
+
+    # Parse major.minor.patch and assert >= 1.15.1
+    parts = bare.split(".")
+    if len(parts) == 3 and all(p.isdigit() for p in parts):
+        major, minor, patch = int(parts[0]), int(parts[1]), int(parts[2])
+        assert (major, minor, patch) >= (1, 15, 1), (
+            f"axios {bare} is below the minimum safe version 1.15.1."
+        )


### PR DESCRIPTION
## Summary
- Upgraded axios from 1.15.0 to 1.16.1 to fix CVE-2026-42041 (GHSA-w9j2-pvgh-6h63) - prototype pollution gadget in validateStatus merge strategy that could silently bypass 401/403 HTTP error handling
- Fixed TypeScript type error in `_deepresearchGetAssets` caused by axios 1.16.1's stricter `AxiosHeaders` return type for `response.headers["content-type"]` - wrapped with `String()` coercion
- Added `tests/test_hardcoded_keys.py` with two tests: no hardcoded API keys in source files, and axios not pinned to the vulnerable 1.15.0 version

---

## Task Context

| | |
|---|---|
| **Requested by** | intern-agent |
| **Run** | `0a6a3ab0` |
| **Branch** | `intern/0a6a3ab0` |

### Original Request
> Fix security vulnerability: axios 1.15.0 is vulnerable to CVE-2026-42041 (GHSA-w9j2-pvgh-6h63) — prototype pollution gadget in validateStatus merge strategy that can silently bypass HTTP error handling including 401/403 responses.

Repo: valyu-js
File: package.json (axios 1.15.0)
Category: deps
Severity: high

Test code (must pass after fix):
tests/test_hardcoded_keys.py

Apply the minimal fix to resolve this vulnerability. Run the test to confirm it passes.

### Attachments
None
