### PR TITLE
Add title and total_word_count to DeepResearch response types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "valyu-js",
-  "version": "2.7.16",
+  "version": "2.7.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "valyu-js",
-      "version": "2.7.16",
+      "version": "2.7.17",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.15.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "valyu-js",
-  "version": "2.7.16",
+  "version": "2.7.17",
   "description": "Deepsearch API for AI.",
   "files": [
     "dist"

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,7 +47,7 @@ import {
   DatasourcesCategoriesResponse,
 } from "./types";
 
-const SDK_VERSION = "2.7.16";
+const SDK_VERSION = "2.7.17";
 
 /** Normalize API job response (snake_case) to SDK format (camelCase). */
 function normalizeContentsJobResponse(api: Record<string, any>): ContentsJobResponse {

--- a/src/types.ts
+++ b/src/types.ts
@@ -584,6 +584,8 @@ export interface DeepResearchStatusResponse {
   completed_at?: string; // ISO 8601 timestamp string
   output?: string | Record<string, any>;
   output_type?: DeepResearchOutputType;
+  title?: string; // Auto-generated report title
+  total_word_count?: number; // Total word count of the synthesised report
   pdf_url?: string;
   images?: ImageMetadata[];
   deliverables?: DeliverableResult[];
@@ -604,6 +606,7 @@ export interface DeepResearchTaskListItem {
   deepresearch_id: string;
   query: string; // Research query
   input?: string; // Deprecated: use query instead
+  title?: string; // Auto-generated report title
   status: DeepResearchStatus;
   created_at: number;
   public?: boolean;


### PR DESCRIPTION
The data-router DeepResearch endpoint returns `title` (auto-generated report title) and `total_word_count` (total word count of the synthesised report) on every completed task, and the list endpoint returns `title` per task. These arrive over the wire but were not declared in `src/types.ts`, so TypeScript callers got no autocomplete and had to rely on casts.

Changes:
- `DeepResearchStatusResponse`: add `title?: string` and `total_word_count?: number`
- `DeepResearchTaskListItem`: add `title?: string`
- Bump patch version 2.7.16 -> 2.7.17 (package.json, package-lock.json, SDK_VERSION in src/index.ts)

All fields are optional, so existing callers and older server responses without them stay compatible.