### PR TITLE
Add historicalCache support and contents date filters

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "valyu-js",
-  "version": "2.7.17",
+  "version": "2.7.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "valyu-js",
-      "version": "2.7.17",
+      "version": "2.7.18",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.15.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "valyu-js",
-  "version": "2.7.17",
+  "version": "2.7.18",
   "description": "Deepsearch API for AI.",
   "files": [
     "dist"

--- a/src/index.ts
+++ b/src/index.ts
@@ -351,6 +351,7 @@ export class Valyu {
    * @param options.category - Category filter for search results
    * @param options.startDate - Start date filter (YYYY-MM-DD format)
    * @param options.endDate - End date filter (YYYY-MM-DD format)
+   * @param options.historicalCache - When true and a date range is set, return the newest cached snapshot inside the range instead of the latest crawl. No-op without a date range (default: false)
    * @param options.countryCode - Country code filter for search results
    * @param options.responseLength - Response content length: "short"/"medium"/"large"/"max" or integer character count
    * @param options.fastMode - Fast mode for quicker but shorter results (default: false)
@@ -543,6 +544,10 @@ export class Valyu {
         payload.end_date = options.endDate;
       }
 
+      if (options.historicalCache !== undefined) {
+        payload.historical_cache = options.historicalCache;
+      }
+
       if (options.countryCode !== undefined) {
         payload.country_code = options.countryCode;
       }
@@ -606,6 +611,9 @@ export class Valyu {
    * @param options.screenshot - Request page screenshots (default: false)
    * @param options.async - Force async processing (required for >10 URLs)
    * @param options.webhookUrl - HTTPS URL for completion notification (async only)
+   * @param options.startDate - Start date filter (YYYY-MM-DD format), inclusive
+   * @param options.endDate - End date filter (YYYY-MM-DD format), inclusive
+   * @param options.historicalCache - When true and a date range is set, return the newest cached snapshot inside the range instead of the latest crawl. No-op without a date range (default: false)
    * @returns Promise resolving to sync results or async job (when async: true or >10 URLs)
    */
   async contents(
@@ -755,6 +763,18 @@ export class Valyu {
         payload.webhook_url = options.webhookUrl;
       }
 
+      if (options.startDate !== undefined) {
+        payload.start_date = options.startDate;
+      }
+
+      if (options.endDate !== undefined) {
+        payload.end_date = options.endDate;
+      }
+
+      if (options.historicalCache !== undefined) {
+        payload.historical_cache = options.historicalCache;
+      }
+
       const response = await this.client.post(`${this.baseUrl}/contents`, payload, {
         headers: this.headers,
       });
@@ -876,6 +896,7 @@ export class Valyu {
    * @param options.search.excludedSources - Array of source types to exclude (e.g., ["web", "patent"])
    * @param options.search.startDate - Start date filter in ISO format (YYYY-MM-DD)
    * @param options.search.endDate - End date filter in ISO format (YYYY-MM-DD)
+   * @param options.search.historicalCache - When true and a date range is set, searches return the newest cached snapshot inside the range instead of the latest crawl. Locked for the whole research run — the agent cannot toggle it mid-research
    * @param options.search.category - Category filter for search results
    */
   private async _deepresearchCreate(
@@ -963,6 +984,9 @@ export class Valyu {
         }
         if (options.search.endDate) {
           payload.search.end_date = options.search.endDate;
+        }
+        if (options.search.historicalCache !== undefined) {
+          payload.search.historical_cache = options.search.historicalCache;
         }
         if (options.search.category) {
           payload.search.category = options.search.category;
@@ -1435,6 +1459,7 @@ export class Valyu {
    * @param options.search.excludedSources - Array of source types to exclude (e.g., ["web", "patent"])
    * @param options.search.startDate - Start date filter in ISO format (YYYY-MM-DD)
    * @param options.search.endDate - End date filter in ISO format (YYYY-MM-DD)
+   * @param options.search.historicalCache - When true and a date range is set, searches return the newest cached snapshot inside the range instead of the latest crawl
    * @param options.search.category - Category filter for search results
    * @param options.webhookUrl - Optional HTTPS URL for completion notification
    * @param options.metadata - Optional metadata key-value pairs
@@ -1470,6 +1495,9 @@ export class Valyu {
         }
         if (options.search.endDate) {
           payload.search.end_date = options.search.endDate;
+        }
+        if (options.search.historicalCache !== undefined) {
+          payload.search.historical_cache = options.search.historicalCache;
         }
         if (options.search.category) {
           payload.search.category = options.search.category;

--- a/src/types.ts
+++ b/src/types.ts
@@ -79,6 +79,7 @@ export interface SearchOptions {
   category?: string;
   startDate?: string;
   endDate?: string;
+  historicalCache?: boolean; // When true and a date range is set, return the newest cached snapshot inside the range instead of the latest crawl
   countryCode?: CountryCode;
   responseLength?: ResponseLength;
   fastMode?: boolean;
@@ -122,6 +123,9 @@ export interface ContentsOptions {
   screenshot?: boolean;
   async?: boolean;
   webhookUrl?: string;
+  startDate?: string; // ISO date format (YYYY-MM-DD), inclusive
+  endDate?: string; // ISO date format (YYYY-MM-DD), inclusive
+  historicalCache?: boolean; // When true and a date range is set, return the newest cached snapshot inside the range instead of the latest crawl
 }
 
 // ContentResult - discriminated union (success | failed)
@@ -409,6 +413,7 @@ export interface DeepResearchSearchConfig {
   sourceBiases?: Record<string, number>;
   startDate?: string; // ISO date format (YYYY-MM-DD)
   endDate?: string; // ISO date format (YYYY-MM-DD)
+  historicalCache?: boolean; // When true and a date range is set, searches return the newest cached snapshot inside the range; locked for the whole research run (the agent cannot toggle it)
   category?: string;
   countryCode?: CountryCode; // Country code for location-filtered searches
 }


### PR DESCRIPTION
## Summary

Adds support for the new `historical_cache` parameter and extends date-range filtering to the Contents API.

### New request options
- **`search()`:** new `historicalCache` option → `historical_cache`. When `true` and a date range (`startDate`/`endDate`) is set, results return the newest cached snapshot inside the range instead of the latest crawl. No-op without a date range.
- **`contents()`:** new `startDate`, `endDate` (YYYY-MM-DD, inclusive) and `historicalCache` options → `start_date`/`end_date`/`historical_cache`. Applies to both sync and async (`async: true`) jobs — same request body.
- **`DeepResearchSearchConfig`:** new `historicalCache` field, forwarded under the nested `search` object on task creation and batch creation. Locked for the whole research run — the agent cannot toggle it mid-research.

### Response fields
No changes needed — `publication_date` already exists on `SearchResult` and `ContentResultSuccess` and is the only date field surfaced by the API.

### Notes
- All three options are omitted from the request payload when unset (no behavior change for existing callers).
- Version bumped 2.7.17 → 2.7.18 (package.json + package-lock.json).

## Testing
- `npm run build` passes (tsup CJS/ESM/DTS — full typecheck).