### PR TITLE
Add Workflows API support

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,57 @@ const result = await valyu.batch.waitForCompletion(batch.batch_id, {
 });
 ```
 
+### Workflows
+
+Templated DeepResearch starting points - curated by Valyu or created by your org - with typed `{variable}` placeholders and version history.
+
+```typescript
+// Browse curated workflows
+const catalog = await valyu.workflows.list({ scope: "valyu", vertical: "investment-banking" });
+for (const wf of catalog.workflows ?? []) {
+  console.log(`${wf.slug} - ${wf.title}`);
+}
+
+// Run one as a DeepResearch task
+const task = await valyu.deepresearch.create({
+  workflowId: "ib-company-profile",
+  workflowParams: { company: "NVIDIA (NVDA)" },
+});
+
+const result = await valyu.deepresearch.wait(task.deepresearch_id);
+console.log(result.output);
+```
+
+Create your own:
+
+```typescript
+await valyu.workflows.create({
+  slug: "weekly-competitor-scan",
+  title: "Weekly Competitor Scan",
+  version: {
+    prompt: "Summarize the week's most important developments at {company}.",
+    strategy: "Prioritize primary sources: filings, press releases, earnings calls.",
+    report_format: "Bullet-point briefing, grouped by theme.",
+    variables: [{ key: "company", label: "Company", required: true }],
+  },
+});
+```
+
+<details>
+<summary>All Workflows methods</summary>
+
+| Method | Description |
+|---|---|
+| `list(options?)` | List available workflows (filter by vertical, scope, tags, free text) |
+| `get(slug, version?)` | Get a workflow's full template |
+| `versions(slug)` | List a workflow's version history |
+| `preview(slug, options?)` | Resolve the template without creating a task |
+| `create(options)` | Create an org workflow |
+| `update(slug, options)` | Update metadata and/or publish a new version |
+| `delete(slug)` | Delete an org workflow |
+
+</details>
+
 ### Data Sources
 
 List available data sources programmatically.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "valyu-js",
-  "version": "2.7.18",
+  "version": "2.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "valyu-js",
-      "version": "2.7.18",
+      "version": "2.8.0",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.15.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "valyu-js",
-  "version": "2.7.18",
+  "version": "2.8.0",
   "description": "Deepsearch API for AI.",
   "files": [
     "dist"

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,9 +45,18 @@ import {
   DatasourcesListOptions,
   DatasourcesListResponse,
   DatasourcesCategoriesResponse,
+  WorkflowsListOptions,
+  WorkflowsListResponse,
+  WorkflowResponse,
+  WorkflowVersionsResponse,
+  WorkflowPreviewOptions,
+  WorkflowPreviewResponse,
+  WorkflowCreateOptions,
+  WorkflowUpdateOptions,
+  WorkflowDeleteResponse,
 } from "./types";
 
-const SDK_VERSION = "2.7.17";
+const SDK_VERSION = "2.8.0";
 
 /** Normalize API job response (snake_case) to SDK format (camelCase). */
 function normalizeContentsJobResponse(api: Record<string, any>): ContentsJobResponse {
@@ -179,6 +188,23 @@ export class Valyu {
     categories: () => Promise<DatasourcesCategoriesResponse>;
   };
 
+  // Workflows API namespace
+  public workflows: {
+    list: (options?: WorkflowsListOptions) => Promise<WorkflowsListResponse>;
+    get: (slug: string, version?: number) => Promise<WorkflowResponse>;
+    versions: (slug: string) => Promise<WorkflowVersionsResponse>;
+    preview: (
+      slug: string,
+      options?: WorkflowPreviewOptions
+    ) => Promise<WorkflowPreviewResponse>;
+    create: (options: WorkflowCreateOptions) => Promise<WorkflowResponse>;
+    update: (
+      slug: string,
+      options: WorkflowUpdateOptions
+    ) => Promise<WorkflowResponse>;
+    delete: (slug: string) => Promise<WorkflowDeleteResponse>;
+  };
+
   constructor(apiKey?: string, baseUrl: string = "https://api.valyu.ai/v1") {
     if (!apiKey) {
       apiKey = process.env.VALYU_API_KEY;
@@ -236,6 +262,17 @@ export class Valyu {
     this.datasources = {
       list: this._datasourcesList.bind(this),
       categories: this._datasourcesCategories.bind(this),
+    };
+
+    // Initialize Workflows namespace
+    this.workflows = {
+      list: this._workflowsList.bind(this),
+      get: this._workflowsGet.bind(this),
+      versions: this._workflowsVersions.bind(this),
+      preview: this._workflowsPreview.bind(this),
+      create: this._workflowsCreate.bind(this),
+      update: this._workflowsUpdate.bind(this),
+      delete: this._workflowsDelete.bind(this),
     };
   }
 
@@ -905,6 +942,55 @@ export class Valyu {
     try {
       // Use query field (input is supported for backward compatibility)
       const queryValue = options.query ?? options.input;
+
+      // Workflow runs: the template supplies the freeform fields
+      if (options.workflowId) {
+        if (
+          queryValue ||
+          options.strategy ||
+          options.researchStrategy ||
+          options.reportFormat
+        ) {
+          return {
+            success: false,
+            error:
+              "workflowId is mutually exclusive with query/input/researchStrategy/reportFormat - the workflow template supplies those fields",
+          };
+        }
+        const payload: Record<string, any> = {
+          workflow_id: options.workflowId,
+        };
+        if (options.workflowParams !== undefined) {
+          payload.workflow_params = options.workflowParams;
+        }
+        if (options.workflowVersion !== undefined) {
+          payload.workflow_version = options.workflowVersion;
+        }
+        // Only send mode/output_formats when explicitly set so the
+        // workflow's recommended defaults apply otherwise
+        const explicitMode = options.mode ?? options.model;
+        if (explicitMode) payload.mode = explicitMode;
+        if (options.outputFormats) payload.output_formats = options.outputFormats;
+        if (options.tools) payload.tools = options.tools;
+        if (options.webhookUrl) payload.webhook_url = options.webhookUrl;
+        if (options.alertEmail) {
+          payload.alert_email =
+            typeof options.alertEmail === "string"
+              ? options.alertEmail
+              : {
+                  email: options.alertEmail.email,
+                  custom_url: options.alertEmail.custom_url,
+                };
+        }
+        if (options.metadata) payload.metadata = options.metadata;
+
+        const response = await this.client.post(
+          `${this.baseUrl}/deepresearch/tasks`,
+          payload,
+          { headers: this.headers }
+        );
+        return { success: true, ...response.data };
+      }
 
       // Validation
       if (!queryValue?.trim()) {
@@ -2212,6 +2298,200 @@ export class Valyu {
       };
     }
   }
+
+  /** Extract the most descriptive error message from a Workflows API error. */
+  private workflowError(e: any): string {
+    return e.response?.data?.message || e.response?.data?.error || e.message;
+  }
+
+  /**
+   * Workflows: List workflows available to your org
+   * @param options - Filters: vertical, scope ("valyu" | "org" | "all"), q, tags, limit, expand
+   */
+  private async _workflowsList(
+    options: WorkflowsListOptions = {}
+  ): Promise<WorkflowsListResponse> {
+    try {
+      const params = new URLSearchParams();
+      if (options.vertical) params.append("vertical", options.vertical);
+      if (options.scope) params.append("scope", options.scope);
+      if (options.q) params.append("q", options.q);
+      if (options.tags?.length) params.append("tags", options.tags.join(","));
+      if (options.limit !== undefined) {
+        params.append("limit", String(options.limit));
+      }
+      if (options.expand) params.append("expand", "true");
+
+      const url = `${this.baseUrl}/workflows${
+        params.toString() ? `?${params.toString()}` : ""
+      }`;
+      const response = await this.client.get(url, { headers: this.headers });
+
+      return { success: true, ...response.data };
+    } catch (e: any) {
+      return { success: false, error: this.workflowError(e) };
+    }
+  }
+
+  /**
+   * Workflows: Get a workflow's full detail, including its template
+   * @param slug - Workflow slug
+   * @param version - Specific version to fetch (defaults to the current version)
+   */
+  private async _workflowsGet(
+    slug: string,
+    version?: number
+  ): Promise<WorkflowResponse> {
+    try {
+      const url = `${this.baseUrl}/workflows/${encodeURIComponent(slug)}${
+        version !== undefined ? `?version=${version}` : ""
+      }`;
+      const response = await this.client.get(url, { headers: this.headers });
+
+      return { success: true, workflow: response.data };
+    } catch (e: any) {
+      return { success: false, error: this.workflowError(e) };
+    }
+  }
+
+  /**
+   * Workflows: List a workflow's version history
+   * @param slug - Workflow slug
+   */
+  private async _workflowsVersions(
+    slug: string
+  ): Promise<WorkflowVersionsResponse> {
+    try {
+      const response = await this.client.get(
+        `${this.baseUrl}/workflows/${encodeURIComponent(slug)}/versions`,
+        { headers: this.headers }
+      );
+
+      return { success: true, ...response.data };
+    } catch (e: any) {
+      return { success: false, error: this.workflowError(e) };
+    }
+  }
+
+  /**
+   * Workflows: Resolve a workflow's template with params without creating a task
+   * @param slug - Workflow slug
+   * @param options - workflowParams (variable values) and optional workflowVersion
+   */
+  private async _workflowsPreview(
+    slug: string,
+    options: WorkflowPreviewOptions = {}
+  ): Promise<WorkflowPreviewResponse> {
+    try {
+      const payload: Record<string, any> = {};
+      if (options.workflowParams !== undefined) {
+        payload.workflow_params = options.workflowParams;
+      }
+      if (options.workflowVersion !== undefined) {
+        payload.workflow_version = options.workflowVersion;
+      }
+
+      const response = await this.client.post(
+        `${this.baseUrl}/workflows/${encodeURIComponent(slug)}/preview`,
+        payload,
+        { headers: this.headers }
+      );
+
+      return { success: true, ...response.data };
+    } catch (e: any) {
+      return { success: false, error: this.workflowError(e) };
+    }
+  }
+
+  /**
+   * Workflows: Create a new workflow for your org
+   * @param options - slug, title, version (template body), and optional metadata
+   */
+  private async _workflowsCreate(
+    options: WorkflowCreateOptions
+  ): Promise<WorkflowResponse> {
+    try {
+      const payload: Record<string, any> = {
+        slug: options.slug,
+        title: options.title,
+        version: options.version,
+      };
+      if (options.subtitle !== undefined) payload.subtitle = options.subtitle;
+      if (options.description !== undefined) {
+        payload.description = options.description;
+      }
+      if (options.vertical !== undefined) payload.vertical = options.vertical;
+      if (options.tags !== undefined) payload.tags = options.tags;
+      if (options.icon !== undefined) payload.icon = options.icon;
+
+      const response = await this.client.post(
+        `${this.baseUrl}/workflows`,
+        payload,
+        { headers: this.headers }
+      );
+
+      return { success: true, workflow: response.data };
+    } catch (e: any) {
+      return { success: false, error: this.workflowError(e) };
+    }
+  }
+
+  /**
+   * Workflows: Update a workflow's metadata and/or publish a new template version.
+   * Only workflows owned by your org can be updated; versions are append-only
+   * (a version body requires a changelog).
+   * @param slug - Workflow slug
+   * @param options - Metadata fields and/or a new version body
+   */
+  private async _workflowsUpdate(
+    slug: string,
+    options: WorkflowUpdateOptions
+  ): Promise<WorkflowResponse> {
+    try {
+      const payload: Record<string, any> = {};
+      if (options.title !== undefined) payload.title = options.title;
+      if (options.subtitle !== undefined) payload.subtitle = options.subtitle;
+      if (options.description !== undefined) {
+        payload.description = options.description;
+      }
+      if (options.vertical !== undefined) payload.vertical = options.vertical;
+      if (options.tags !== undefined) payload.tags = options.tags;
+      if (options.icon !== undefined) payload.icon = options.icon;
+      if (options.version !== undefined) payload.version = options.version;
+      if (options.setCurrent !== undefined) {
+        payload.set_current = options.setCurrent;
+      }
+
+      const response = await this.client.patch(
+        `${this.baseUrl}/workflows/${encodeURIComponent(slug)}`,
+        payload,
+        { headers: this.headers }
+      );
+
+      return { success: true, workflow: response.data };
+    } catch (e: any) {
+      return { success: false, error: this.workflowError(e) };
+    }
+  }
+
+  /**
+   * Workflows: Delete a workflow owned by your org (soft delete)
+   * @param slug - Workflow slug
+   */
+  private async _workflowsDelete(
+    slug: string
+  ): Promise<WorkflowDeleteResponse> {
+    try {
+      const response = await this.client.delete(
+        `${this.baseUrl}/workflows/${encodeURIComponent(slug)}`,
+        { headers: this.headers }
+      );
+
+      return { success: true, ...response.data };
+    } catch (e: any) {
+      return { success: false, error: this.workflowError(e) };
+    }
+  }
 }
 
 export type {
@@ -2308,4 +2588,24 @@ export type {
   DatasourcesListOptions,
   DatasourcesListResponse,
   DatasourcesCategoriesResponse,
+  WorkflowMode,
+  WorkflowVariableType,
+  WorkflowVariableValidation,
+  WorkflowVariable,
+  WorkflowDeliverable,
+  WorkflowTools,
+  Workflow,
+  WorkflowVersionSummary,
+  WorkflowRunInfo,
+  ResolvedWorkflowTemplate,
+  WorkflowVersionInput,
+  WorkflowsListOptions,
+  WorkflowCreateOptions,
+  WorkflowUpdateOptions,
+  WorkflowPreviewOptions,
+  WorkflowsListResponse,
+  WorkflowResponse,
+  WorkflowVersionsResponse,
+  WorkflowPreviewResponse,
+  WorkflowDeleteResponse,
 } from "./types";

--- a/src/types.ts
+++ b/src/types.ts
@@ -460,6 +460,9 @@ export interface DeepResearchCreateOptions {
   brandCollectionId?: string;
   metadata?: Record<string, string | number | boolean>;
   hitl?: HitlConfig; // Human-in-the-loop configuration (not available for batch)
+  workflowId?: string; // Workflow slug to run — the template supplies query/strategy/format. Mutually exclusive with query/input/researchStrategy/reportFormat
+  workflowParams?: Record<string, any>; // Values for the workflow's variables
+  workflowVersion?: number; // Specific workflow version to run (defaults to current)
 }
 
 // Human-in-the-Loop (HITL) Types
@@ -572,6 +575,7 @@ export interface DeepResearchCreateResponse {
   public?: boolean;
   webhook_secret?: string;
   message?: string;
+  workflow?: WorkflowRunInfo; // Present when the task was created from a workflow
   error?: string;
 }
 
@@ -933,5 +937,183 @@ export interface DatasourcesListResponse {
 export interface DatasourcesCategoriesResponse {
   success: boolean;
   categories?: DatasourceCategory[];
+  error?: string;
+}
+
+// Workflows API Types
+// Workflows are templated DeepResearch starting points with typed {variable}
+// placeholders and version history. Run one by passing workflowId to
+// deepresearch.create().
+
+export type WorkflowMode = "fast" | "standard" | "heavy" | "max";
+
+export type WorkflowVariableType =
+  | "text"
+  | "textarea"
+  | "number"
+  | "date"
+  | "enum";
+
+export interface WorkflowVariableValidation {
+  min_length?: number;
+  max_length?: number;
+  pattern?: string;
+  enum?: string[];
+}
+
+export interface WorkflowVariable {
+  key: string;
+  label?: string;
+  type?: WorkflowVariableType;
+  required?: boolean;
+  placeholder?: string;
+  help?: string;
+  examples?: string[];
+  validation?: WorkflowVariableValidation;
+}
+
+export interface WorkflowDeliverable {
+  type: string;
+  description?: string;
+}
+
+export interface WorkflowTools {
+  code_execution?: boolean;
+  screenshots?: boolean;
+  browser_use?: boolean;
+  charts?: boolean;
+}
+
+export interface Workflow {
+  slug: string;
+  version?: number;
+  vertical?: string | null;
+  tags?: string[];
+  title?: string;
+  subtitle?: string | null;
+  description?: string | null;
+  popular?: boolean;
+  recommended_mode?: WorkflowMode;
+  estimated_time?: string | null;
+  is_valyu?: boolean;
+  owner_org_id?: string | null;
+  variables?: WorkflowVariable[];
+  deliverables?: WorkflowDeliverable[];
+  created_at?: string;
+  updated_at?: string;
+  // Template fields — present on detail responses and list with expand=true
+  prompt?: string;
+  strategy?: string;
+  report_format?: string;
+  tools?: WorkflowTools;
+  changelog?: string | null;
+}
+
+export interface WorkflowVersionSummary {
+  version: number;
+  recommended_mode?: WorkflowMode;
+  estimated_time?: string | null;
+  changelog?: string | null;
+  created_at?: string;
+  is_current?: boolean;
+}
+
+export interface WorkflowRunInfo {
+  slug?: string;
+  version?: number;
+}
+
+export interface ResolvedWorkflowTemplate {
+  input?: string;
+  research_strategy?: string;
+  report_format?: string;
+  deliverables?: WorkflowDeliverable[];
+  mode?: WorkflowMode;
+  tools?: WorkflowTools;
+}
+
+/** Template body for creating a workflow or publishing a new version. */
+export interface WorkflowVersionInput {
+  prompt: string;
+  strategy: string;
+  report_format: string;
+  variables?: WorkflowVariable[];
+  deliverables?: WorkflowDeliverable[];
+  tools?: WorkflowTools;
+  recommended_mode?: WorkflowMode;
+  estimated_time?: string;
+  changelog?: string;
+}
+
+export interface WorkflowsListOptions {
+  vertical?: string;
+  scope?: "valyu" | "org" | "all";
+  q?: string;
+  tags?: string[];
+  limit?: number;
+  expand?: boolean;
+}
+
+export interface WorkflowCreateOptions {
+  slug: string;
+  title: string;
+  version: WorkflowVersionInput;
+  subtitle?: string;
+  description?: string;
+  vertical?: string;
+  tags?: string[];
+  icon?: string;
+}
+
+export interface WorkflowUpdateOptions {
+  title?: string;
+  subtitle?: string;
+  description?: string;
+  vertical?: string;
+  tags?: string[];
+  icon?: string;
+  version?: WorkflowVersionInput;
+  setCurrent?: boolean;
+}
+
+export interface WorkflowPreviewOptions {
+  workflowParams?: Record<string, any>;
+  workflowVersion?: number;
+}
+
+export interface WorkflowsListResponse {
+  success: boolean;
+  workflows?: Workflow[];
+  total?: number;
+  next_cursor?: string | null;
+  verticals?: string[];
+  error?: string;
+}
+
+export interface WorkflowResponse {
+  success: boolean;
+  workflow?: Workflow;
+  error?: string;
+}
+
+export interface WorkflowVersionsResponse {
+  success: boolean;
+  slug?: string;
+  versions?: WorkflowVersionSummary[];
+  error?: string;
+}
+
+export interface WorkflowPreviewResponse {
+  success: boolean;
+  workflow?: WorkflowRunInfo;
+  resolved?: ResolvedWorkflowTemplate;
+  estimated_credits?: number | null;
+  error?: string;
+}
+
+export interface WorkflowDeleteResponse {
+  success: boolean;
+  slug?: string;
+  deleted_at?: string;
   error?: string;
 }


### PR DESCRIPTION
## Summary

Adds full support for the Workflows API: templated DeepResearch starting points with typed `{variable}` placeholders and version history.

### New: `valyu.workflows` namespace
- `list(options?)` - browse Valyu-curated and org workflows (filters: vertical, scope, q, tags, limit, expand)
- `get(slug, version?)` - full workflow detail including the template
- `versions(slug)` - version history
- `preview(slug, options?)` - resolve the template without creating a task
- `create(options)` / `update(slug, options)` / `delete(slug)` - org workflow CRUD (versions are append-only)

### DeepResearch integration
- `deepresearch.create()` accepts `workflowId`, `workflowParams`, `workflowVersion` to run a workflow as a research task. Mutually exclusive with `query`/`input`/`researchStrategy`/`reportFormat` (validated client-side with a clear error). Mode and output formats are only sent when explicitly set so the workflow's recommended defaults apply.
- `DeepResearchCreateResponse` now includes `workflow: {slug, version}` attribution.

### Other
- TypeScript types for all workflow request/response shapes, exported from the package root
- README section with usage and method table
- Version bump to 2.8.0 (also fixes `SDK_VERSION` header constant lagging package.json)

## Testing

Built with tsup (strict TS) and verified every method against the live API: list (all filters + expand), get (current + pinned version + 404), versions, preview (resolution + missing-param validation error), org create -> metadata update -> new version -> version history -> delete, 403 on editing curated workflows, client-side mutual-exclusion error, and a real task created via `workflowId` with correct workflow attribution (then cancelled). All passed.