### PR TITLE
Fix publish workflow: track Node 22.x so the npm OIDC upgrade step works

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,7 @@ jobs:
 
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
-          node-version: '22.14.0'
+          node-version: '22'
 
       - name: Install dependencies
         run: npm ci
@@ -41,7 +41,7 @@ jobs:
 
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
-          node-version: '22.14.0'
+          node-version: '22'
 
       - name: Upgrade npm for OIDC support
         run: npm install -g npm@latest


### PR DESCRIPTION
## Summary

The publish job on main failed on the last release attempt: the "Upgrade npm for OIDC support" step runs `npm install -g npm@latest`, and npm 12 now requires Node `^22.22.2 || ^24.15.0 || >=26.0.0`, but the workflow pins Node at exactly `22.14.0`. Every release fails with `EBADENGINE` until the runner's Node moves.

This changes `node-version` from the exact `22.14.0` pin to `'22'` (latest 22.x) in both jobs, which keeps the runner compatible as npm's engine floor moves within the major.

Once merged, the publish job will run on this push and release the pending 2.9.1 (axios 1.18.1 security bump from #168), which is already on main but unpublished due to this failure.

## Verification

- Failure mode confirmed from the run logs of the last publish attempt (`npm error notsup Required: {"node":"^22.22.2 || ^24.15.0 || >=26.0.0"}, Actual: {"npm":"10.9.2","node":"v22.14.0"}`)
- Local build passes on Node 22.x with `npm ci && npm run build`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/valyuAI/codesmith/valyu-js/pr/169"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786262044&installation_id=141286747&pr_number=169&repository=valyuAI%2Fvalyu-js&return_to=https%3A%2F%2Fgithub.com%2FvalyuAI%2Fvalyu-js%2Fpull%2F169&signature=1ad984919eb7d279f3de1ab6547eedc9d5369d897c4ec7d1c4bc142fc1fea2d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->