### PR TITLE
Pin npm to 11.x in publish workflow to unbreak provenance publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -44,7 +44,10 @@ jobs:
           node-version: '22'
 
       - name: Upgrade npm for OIDC support
-        run: npm install -g npm@latest
+        # npm 12.0.0 breaks `npm publish --provenance` (its global install
+        # drops the sigstore module that libnpmpublish still requires), so
+        # stay on the 11.x line until 12 is fixed.
+        run: npm install -g npm@11
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
## Summary

Follow-up to #169. With Node 22.x current, `npm install -g npm@latest` now installs npm 12.0.0, whose global install removes the `sigstore` module that `libnpmpublish` still requires - so `npm publish --provenance` fails with `MODULE_NOT_FOUND: Cannot find module 'sigstore'` (see the publish job on the previous main push).

This pins the upgrade step to `npm@11` (currently 11.18.0), which supports OIDC trusted publishing and publishes with provenance cleanly. Once merged, the publish job on this push should release the pending 2.9.1.

## Verification

- Failure reproduced in the publish run for the #169 merge commit: upgrade step logs show npm 12 "removed 71 packages", publish step fails requiring `sigstore` from `libnpmpublish/lib/provenance.js`
- npm 11.x is the last known-good line for `--provenance` with OIDC

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/valyuAI/codesmith/valyu-js/pr/170"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786262230&installation_id=141286747&pr_number=170&repository=valyuAI%2Fvalyu-js&return_to=https%3A%2F%2Fgithub.com%2FvalyuAI%2Fvalyu-js%2Fpull%2F170&signature=0b4b83ebdd87debaf99c7a311f38f1d3cd5b33e2ad1d1342a2dc6e7bb52c9063"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->