### PR TITLE
Align researchStrategy/reportFormat length guard with server 400

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,12 @@
+/** @type {import('ts-jest').JestConfigWithTsJest} */
+module.exports = {
+  preset: "ts-jest",
+  testEnvironment: "node",
+  testMatch: ["**/tests/**/*.test.ts"],
+  transform: {
+    "^.+\\.tsx?$": [
+      "ts-jest",
+      { tsconfig: { module: "commonjs", noUnusedLocals: false } },
+    ],
+  },
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "valyu-js",
-  "version": "2.9.1",
+  "version": "2.9.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "valyu-js",
-      "version": "2.9.1",
+      "version": "2.9.2",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.18.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "valyu-js",
-  "version": "2.9.1",
+  "version": "2.9.2",
   "description": "Deepsearch API for AI.",
   "files": [
     "dist"

--- a/src/index.ts
+++ b/src/index.ts
@@ -56,7 +56,15 @@ import {
   WorkflowDeleteResponse,
 } from "./types";
 
-const SDK_VERSION = "2.9.1";
+const SDK_VERSION = "2.9.2";
+
+/**
+ * Maximum combined character length of research_strategy (or its legacy
+ * alias strategy) and report_format accepted by the DeepResearch create
+ * endpoint. The server rejects anything strictly greater than this with a
+ * 400. Enforced client-side so the caller fails fast without a round trip.
+ */
+const MAX_STRATEGY_REPORT_FORMAT_COMBINED_LENGTH = 15000;
 
 /**
  * HTTP status codes that indicate a transient gateway/server/rate-limit
@@ -947,6 +955,20 @@ export class Valyu {
     options: DeepResearchCreateOptions
   ): Promise<DeepResearchCreateResponse> {
     try {
+      // Enforce the server's combined-length cap on research_strategy (or its
+      // legacy alias strategy) plus report_format before doing any work, so the
+      // client-side error matches the server's 400 body exactly and no request
+      // is made when the payload is guaranteed to be rejected.
+      const effectiveStrategy = options.researchStrategy ?? options.strategy;
+      const combined =
+        (effectiveStrategy?.length ?? 0) + (options.reportFormat?.length ?? 0);
+      if (combined > MAX_STRATEGY_REPORT_FORMAT_COMBINED_LENGTH) {
+        return {
+          success: false,
+          error: `research_strategy and report_format combined length (${combined}) exceeds 15,000 character limit`,
+        };
+      }
+
       // Use query field (input is supported for backward compatibility)
       const queryValue = options.query ?? options.input;
 
@@ -1011,15 +1033,6 @@ export class Valyu {
         return {
           success: false,
           error: `query exceeds 25,000 character limit (${queryValue.length} characters)`,
-        };
-      }
-
-      const strategyLen = (options.researchStrategy ?? "").length;
-      const formatLen = (options.reportFormat ?? "").length;
-      if (strategyLen + formatLen > 15000) {
-        return {
-          success: false,
-          error: `Combined length of researchStrategy (${strategyLen}) and reportFormat (${formatLen}) exceeds 15,000 character limit`,
         };
       }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -444,8 +444,8 @@ export interface DeepResearchCreateOptions {
   model?: DeepResearchMode; // Deprecated: use mode instead (backward compatible)
   outputFormats?: DeepResearchOutputFormat[];
   strategy?: string; // Deprecated: use researchStrategy instead
-  researchStrategy?: string; // Natural language strategy to guide the research phase
-  reportFormat?: string; // Natural language instructions for output format (highest priority)
+  researchStrategy?: string; // Natural language strategy to guide the research phase. Combined length of researchStrategy (or legacy strategy) and reportFormat must not exceed 15,000 characters.
+  reportFormat?: string; // Natural language instructions for output format (highest priority). Combined length of researchStrategy (or legacy strategy) and reportFormat must not exceed 15,000 characters.
   search?: DeepResearchSearchConfig;
   urls?: string[];
   files?: FileAttachment[];

--- a/src/types.ts
+++ b/src/types.ts
@@ -411,9 +411,9 @@ export interface DeepResearchSearchConfig {
   includedSources?: string[];
   excludedSources?: string[];
   sourceBiases?: Record<string, number>;
-  startDate?: string; // ISO date format (YYYY-MM-DD)
-  endDate?: string; // ISO date format (YYYY-MM-DD)
-  historicalCache?: boolean; // When true and a date range is set, searches return the newest cached snapshot inside the range; locked for the whole research run (the agent cannot toggle it)
+  startDate?: string; // Inclusive start bound. Bare date (YYYY-MM-DD) or full ISO-8601 datetime; a datetime with any time component requires historicalCache=true, else HTTP 400
+  endDate?: string; // Inclusive end bound. Bare date (YYYY-MM-DD) or full ISO-8601 datetime; a datetime with any time component requires historicalCache=true, else HTTP 400
+  historicalCache?: boolean; // When true and a date range is set, searches return the newest cached snapshot inside the range (leak-safe as-of backtest) instead of the latest crawl. Also required to pass any sub-day timestamp on startDate/endDate. No-op without a date range. User-set only; locked for the whole research run (the agent cannot toggle it)
   category?: string;
   countryCode?: CountryCode; // Country code for location-filtered searches
 }

--- a/tests/deepresearch-length-cap.test.ts
+++ b/tests/deepresearch-length-cap.test.ts
@@ -1,0 +1,67 @@
+import { Valyu } from "../src/index";
+
+/**
+ * The DeepResearch create endpoint rejects requests whose combined
+ * research_strategy (or legacy strategy) + report_format length is strictly
+ * greater than 15,000 characters. These tests verify the client-side pre-check
+ * short-circuits at 15,001 without a network call, and lets 15,000 through.
+ */
+describe("deepresearch.create combined length cap", () => {
+  const MAX = 15000;
+
+  function makeClient(): { valyu: Valyu; post: jest.Mock } {
+    const valyu = new Valyu("test-key", "https://api.valyu.ai/v1");
+    // Replace the axios instance's post so nothing ever hits the network.
+    const post = jest
+      .fn()
+      .mockResolvedValue({ data: { task_id: "task_123", status: "queued" } });
+    (valyu as any).client.post = post;
+    return { valyu, post };
+  }
+
+  it("does not short-circuit at exactly 15,000 combined characters", async () => {
+    const { valyu, post } = makeClient();
+
+    const result = await valyu.deepresearch.create({
+      query: "some research question",
+      researchStrategy: "a".repeat(MAX),
+      // reportFormat omitted -> combined === 15000, which is allowed
+    });
+
+    // The guard let the request through to the network layer.
+    expect(post).toHaveBeenCalledTimes(1);
+    expect(result.success).toBe(true);
+  });
+
+  it("returns the server-identical error at 15,001 without a network call", async () => {
+    const { valyu, post } = makeClient();
+
+    const result = await valyu.deepresearch.create({
+      query: "some research question",
+      researchStrategy: "a".repeat(MAX),
+      reportFormat: "b", // combined === 15001, first failing value
+    });
+
+    expect(post).not.toHaveBeenCalled();
+    expect(result.success).toBe(false);
+    expect(result.error).toBe(
+      "research_strategy and report_format combined length (15001) exceeds 15,000 character limit"
+    );
+  });
+
+  it("counts the legacy strategy alias toward the cap", async () => {
+    const { valyu, post } = makeClient();
+
+    const result = await valyu.deepresearch.create({
+      query: "some research question",
+      strategy: "a".repeat(MAX),
+      reportFormat: "b", // combined === 15001 via legacy alias
+    });
+
+    expect(post).not.toHaveBeenCalled();
+    expect(result.success).toBe(false);
+    expect(result.error).toBe(
+      "research_strategy and report_format combined length (15001) exceeds 15,000 character limit"
+    );
+  });
+});


### PR DESCRIPTION
## What

The DeepResearch create endpoint enforces a hard cap: the combined character length of `researchStrategy` (or its legacy alias `strategy`) and `reportFormat` must not exceed **15,000 characters**. Over the limit, the server returns HTTP 400 with error `research_strategy and report_format combined length (N) exceeds 15,000 character limit`. Boundary is inclusive — exactly 15000 passes, 15001 is the first failure. `query` and research content do **not** count.

## Why

A pre-existing client-side guard in `_deepresearchCreate` only counted `researchStrategy` and ignored the legacy `strategy` alias, and emitted a different message than the server. A caller using the old `strategy` field slipped past the client check and hit the server 400 directly.

## Change

- Replace the old guard with a single check that mirrors the server's `researchStrategy ?? strategy` precedence and returns the **exact** server 400 string. Returns `{ success: false, error }` — does not throw — matching the method's existing contract.
- Update `researchStrategy` / `reportFormat` doc comments.
- Add Jest tests (15000 passes the guard, 15001 rejects, alias counts).
- Patch bump 2.9.1 → 2.9.2 and sync `SDK_VERSION`.

Batch path left untouched (cap only confirmed for single create).


<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/valyuAI/codesmith/valyu-js/pr/171"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786631889&installation_id=141286747&pr_number=171&repository=valyuAI%2Fvalyu-js&return_to=https%3A%2F%2Fgithub.com%2FvalyuAI%2Fvalyu-js%2Fpull%2F171&signature=6a9b19be9b8e1a1d3b244a4388f46474fa0984785bed11b79d0a3be569d38e07"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
