### PR TITLE
Workflows API: forward per-run options and surface validation detail

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "valyu-js",
-  "version": "2.9.2",
+  "version": "2.10.0",
   "description": "Deepsearch API for AI.",
   "files": [
     "dist"

--- a/src/index.ts
+++ b/src/index.ts
@@ -56,7 +56,7 @@ import {
   WorkflowDeleteResponse,
 } from "./types";
 
-const SDK_VERSION = "2.9.2";
+const SDK_VERSION = "2.10.0";
 
 /**
  * Maximum combined character length of research_strategy (or its legacy
@@ -131,6 +131,103 @@ export function verifyContentsWebhookSignature(
     Buffer.from(signature, "utf8"),
     Buffer.from(expectedSignature, "utf8")
   );
+}
+
+/**
+ * Build a human-readable error string from an API error response.
+ *
+ * Validation failures carry an `errors` array naming each offending field, so
+ * fold those into the message. Without them a caller only sees a summary like
+ * "2 validation errors", which says nothing about which parameter was wrong or
+ * what the API expected instead.
+ */
+function apiErrorMessage(e: any): string {
+  const data = e?.response?.data;
+  const summary = data?.message || data?.error || e?.message;
+
+  const details: string[] = [];
+  for (const item of Array.isArray(data?.errors) ? data.errors : []) {
+    let detail =
+      item && typeof item === "object" ? item.message || item.code : item;
+    if (detail && item?.key && !String(detail).includes(item.key)) {
+      detail = `${item.key}: ${detail}`;
+    }
+    if (detail) details.push(String(detail));
+  }
+
+  if (!details.length) return String(summary);
+  return `${summary}: ${details.join("; ")}`;
+}
+
+/**
+ * Build the request fields that are valid for both freeform and workflow runs.
+ *
+ * Workflow templates supply the freeform fields (prompt, strategy, report
+ * format) but everything below is a per-run concern, so a workflow run accepts
+ * the same values a freeform run does. Request-body values win over the
+ * template server-side, except `tools`, which is merged with it.
+ */
+function buildSharedFields(
+  options: DeepResearchCreateOptions
+): Record<string, any> {
+  const fields: Record<string, any> = {};
+
+  if (options.tools) {
+    fields.tools = options.tools;
+  } else if (options.codeExecution !== undefined) {
+    // Backward compatibility: top-level code_execution (deprecated)
+    fields.code_execution = options.codeExecution;
+  }
+
+  if (options.search) {
+    const search: Record<string, any> = {};
+    if (options.search.searchType) search.search_type = options.search.searchType;
+    if (options.search.includedSources)
+      search.included_sources = options.search.includedSources;
+    if (options.search.excludedSources)
+      search.excluded_sources = options.search.excludedSources;
+    if (options.search.sourceBiases)
+      search.source_biases = options.search.sourceBiases;
+    if (options.search.startDate) search.start_date = options.search.startDate;
+    if (options.search.endDate) search.end_date = options.search.endDate;
+    if (options.search.historicalCache !== undefined)
+      search.historical_cache = options.search.historicalCache;
+    if (options.search.category) search.category = options.search.category;
+    fields.search = search;
+  }
+
+  if (options.urls) fields.urls = options.urls;
+  if (options.files) fields.files = options.files;
+  if (options.deliverables) fields.deliverables = options.deliverables;
+  if (options.mcpServers) fields.mcp_servers = options.mcpServers;
+  if (options.previousReports) fields.previous_reports = options.previousReports;
+  if (options.webhookUrl) fields.webhook_url = options.webhookUrl;
+  if (options.brandCollectionId)
+    fields.brand_collection_id = options.brandCollectionId;
+  if (options.alertEmail) {
+    fields.alert_email =
+      typeof options.alertEmail === "string"
+        ? options.alertEmail
+        : {
+            email: options.alertEmail.email,
+            custom_url: options.alertEmail.custom_url,
+          };
+  }
+  if (options.metadata) fields.metadata = options.metadata;
+  if (options.hitl) {
+    const hitl: Record<string, any> = {};
+    if (options.hitl.planningQuestions !== undefined)
+      hitl.planning_questions = options.hitl.planningQuestions;
+    if (options.hitl.planReview !== undefined)
+      hitl.plan_review = options.hitl.planReview;
+    if (options.hitl.sourceReview !== undefined)
+      hitl.source_review = options.hitl.sourceReview;
+    if (options.hitl.outlineReview !== undefined)
+      hitl.outline_review = options.hitl.outlineReview;
+    fields.hitl = hitl;
+  }
+
+  return fields;
 }
 
 // Valyu API client
@@ -986,6 +1083,18 @@ export class Valyu {
               "workflowId is mutually exclusive with query/input/researchStrategy/reportFormat - the workflow template supplies those fields",
           };
         }
+        if (options.files) {
+          for (let i = 0; i < options.files.length; i++) {
+            const ctx = options.files[i].context;
+            if (ctx && ctx.length > 10000) {
+              return {
+                success: false,
+                error: `files[${i}].context exceeds 10,000 character limit (${ctx.length} characters)`,
+              };
+            }
+          }
+        }
+
         const payload: Record<string, any> = {
           workflow_id: options.workflowId,
         };
@@ -1000,18 +1109,10 @@ export class Valyu {
         const explicitMode = options.mode ?? options.model;
         if (explicitMode) payload.mode = explicitMode;
         if (options.outputFormats) payload.output_formats = options.outputFormats;
-        if (options.tools) payload.tools = options.tools;
-        if (options.webhookUrl) payload.webhook_url = options.webhookUrl;
-        if (options.alertEmail) {
-          payload.alert_email =
-            typeof options.alertEmail === "string"
-              ? options.alertEmail
-              : {
-                  email: options.alertEmail.email,
-                  custom_url: options.alertEmail.custom_url,
-                };
-        }
-        if (options.metadata) payload.metadata = options.metadata;
+
+        // Per-run options are as valid on a workflow run as on a freeform one —
+        // the template only supplies the freeform fields.
+        Object.assign(payload, buildSharedFields(options));
 
         const response = await this.client.post(
           `${this.baseUrl}/deepresearch/tasks`,
@@ -1057,79 +1158,14 @@ export class Valyu {
         output_formats: options.outputFormats || ["markdown"],
       };
 
-      // Handle tools configuration
-      if (options.tools) {
-        payload.tools = options.tools;
-      } else if (options.codeExecution !== undefined) {
-        // Backward compatibility: top-level code_execution (deprecated)
-        payload.code_execution = options.codeExecution;
-      }
-
-      // Add optional fields
+      // Freeform-only fields — a workflow template supplies these instead
       if (options.strategy) payload.strategy = options.strategy;
       if (options.researchStrategy)
         payload.research_strategy = options.researchStrategy;
       if (options.reportFormat)
         payload.report_format = options.reportFormat;
-      if (options.search) {
-        payload.search = {};
-        if (options.search.searchType) {
-          payload.search.search_type = options.search.searchType;
-        }
-        if (options.search.includedSources) {
-          payload.search.included_sources = options.search.includedSources;
-        }
-        if (options.search.excludedSources) {
-          payload.search.excluded_sources = options.search.excludedSources;
-        }
-        if (options.search.sourceBiases) {
-          payload.search.source_biases = options.search.sourceBiases;
-        }
-        if (options.search.startDate) {
-          payload.search.start_date = options.search.startDate;
-        }
-        if (options.search.endDate) {
-          payload.search.end_date = options.search.endDate;
-        }
-        if (options.search.historicalCache !== undefined) {
-          payload.search.historical_cache = options.search.historicalCache;
-        }
-        if (options.search.category) {
-          payload.search.category = options.search.category;
-        }
-      }
-      if (options.urls) payload.urls = options.urls;
-      if (options.files) payload.files = options.files;
-      if (options.deliverables) payload.deliverables = options.deliverables;
-      if (options.mcpServers) payload.mcp_servers = options.mcpServers;
-      if (options.previousReports) {
-        payload.previous_reports = options.previousReports;
-      }
-      if (options.webhookUrl) payload.webhook_url = options.webhookUrl;
-      if (options.brandCollectionId)
-        payload.brand_collection_id = options.brandCollectionId;
-      if (options.alertEmail) {
-        if (typeof options.alertEmail === "string") {
-          payload.alert_email = options.alertEmail;
-        } else {
-          payload.alert_email = {
-            email: options.alertEmail.email,
-            custom_url: options.alertEmail.custom_url,
-          };
-        }
-      }
-      if (options.metadata) payload.metadata = options.metadata;
-      if (options.hitl) {
-        payload.hitl = {};
-        if (options.hitl.planningQuestions !== undefined)
-          payload.hitl.planning_questions = options.hitl.planningQuestions;
-        if (options.hitl.planReview !== undefined)
-          payload.hitl.plan_review = options.hitl.planReview;
-        if (options.hitl.sourceReview !== undefined)
-          payload.hitl.source_review = options.hitl.sourceReview;
-        if (options.hitl.outlineReview !== undefined)
-          payload.hitl.outline_review = options.hitl.outlineReview;
-      }
+
+      Object.assign(payload, buildSharedFields(options));
 
       const response = await this.client.post(
         `${this.baseUrl}/deepresearch/tasks`,
@@ -1141,7 +1177,7 @@ export class Valyu {
     } catch (e: any) {
       return {
         success: false,
-        error: e.response?.data?.error || e.message,
+        error: apiErrorMessage(e),
       };
     }
   }
@@ -2387,7 +2423,7 @@ export class Valyu {
 
   /** Extract the most descriptive error message from a Workflows API error. */
   private workflowError(e: any): string {
-    return e.response?.data?.message || e.response?.data?.error || e.message;
+    return apiErrorMessage(e);
   }
 
   /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -460,8 +460,15 @@ export interface DeepResearchCreateOptions {
   brandCollectionId?: string;
   metadata?: Record<string, string | number | boolean>;
   hitl?: HitlConfig; // Human-in-the-loop configuration (not available for batch)
-  workflowId?: string; // Workflow slug to run — the template supplies query/strategy/format. Mutually exclusive with query/input/researchStrategy/reportFormat
-  workflowParams?: Record<string, any>; // Values for the workflow's variables
+  // Workflow slug to run — the template supplies query/strategy/format. Mutually
+  // exclusive with query/input/researchStrategy/reportFormat. Every other option
+  // here still applies to a workflow run and overrides the template's value,
+  // except tools, which is merged with it.
+  workflowId?: string;
+  // Values for the workflow's variables. Keys must match the workflow's declared
+  // variables — read them from workflows.get(slug).workflow.variables, since they
+  // differ per workflow.
+  workflowParams?: Record<string, any>;
   workflowVersion?: number; // Specific workflow version to run (defaults to current)
 }
 

--- a/tests/api-error-message.test.ts
+++ b/tests/api-error-message.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Tests that API validation detail survives into SDK error strings.
+ *
+ * The API returns an `errors` array naming each offending field. Keeping only
+ * the summary ("2 validation errors") leaves a caller unable to tell which
+ * parameter was wrong or what the API expected instead.
+ */
+
+import { Valyu } from "../src/index";
+
+function makeClient(rejection: any) {
+  const valyu = new Valyu("val_test");
+  (valyu as any).client = {
+    post: jest.fn().mockRejectedValue(rejection),
+    get: jest.fn().mockRejectedValue(rejection),
+  };
+  return valyu;
+}
+
+const VALIDATION_FAILURE = {
+  response: {
+    status: 400,
+    data: {
+      error: "validation_failed",
+      message: "2 validation errors",
+      errors: [
+        {
+          code: "unknown_param",
+          key: "company",
+          message: 'Unknown parameter "company"',
+        },
+        {
+          code: "missing_param",
+          key: "target",
+          message: 'Required parameter "target" is missing',
+        },
+      ],
+    },
+  },
+  message: "Request failed with status code 400",
+};
+
+describe("API error messages", () => {
+  it("names the offending fields on a workflow run", async () => {
+    const valyu = makeClient(VALIDATION_FAILURE);
+
+    const result = await valyu.deepresearch.create({
+      workflowId: "ib-comps-analysis",
+      workflowParams: { company: "Datadog (DDOG)" },
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("2 validation errors");
+    expect(result.error).toContain('Unknown parameter "company"');
+    expect(result.error).toContain('Required parameter "target" is missing');
+  });
+
+  it("names the offending fields on workflows.preview", async () => {
+    const valyu = makeClient(VALIDATION_FAILURE);
+
+    const result = await valyu.workflows.preview("ib-comps-analysis", {
+      workflowParams: { company: "Datadog (DDOG)" },
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('Unknown parameter "company"');
+  });
+
+  it("prefixes the key when the detail does not name it", async () => {
+    const valyu = makeClient({
+      response: {
+        status: 400,
+        data: {
+          message: "1 validation error",
+          errors: [{ code: "missing_param", key: "sector" }],
+        },
+      },
+      message: "Request failed with status code 400",
+    });
+
+    const result = await valyu.deepresearch.create({
+      workflowId: "ib-precedent-transactions",
+      workflowParams: {},
+    });
+
+    expect(result.error).toContain("sector: missing_param");
+  });
+
+  it("falls back to the summary when there is no errors array", async () => {
+    const valyu = makeClient({
+      response: { status: 402, data: { error: "Insufficient credits" } },
+      message: "Request failed with status code 402",
+    });
+
+    const result = await valyu.deepresearch.create({ query: "a query" });
+
+    expect(result.error).toBe("Insufficient credits");
+  });
+
+  it("falls back to the thrown message when there is no response body", async () => {
+    const valyu = makeClient(new Error("socket hang up"));
+
+    const result = await valyu.deepresearch.create({ query: "a query" });
+
+    expect(result.error).toBe("socket hang up");
+  });
+});

--- a/tests/workflow-payload.test.ts
+++ b/tests/workflow-payload.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Tests that a workflow run sends the same per-run options a freeform run does.
+ *
+ * The workflow template supplies the freeform fields (prompt, strategy, report
+ * format). Everything else — deliverables, search, previousReports, hitl, urls,
+ * files, mcpServers, brandCollectionId — is a per-run concern the API accepts
+ * either way, so it must reach the wire rather than being dropped when
+ * workflowId is set.
+ */
+
+import { readFileSync } from "fs";
+import { join } from "path";
+import { Valyu } from "../src/index";
+
+const packageVersion: string = JSON.parse(
+  readFileSync(join(__dirname, "..", "package.json"), "utf8")
+).version;
+
+/** Per-run options that must survive on both code paths. */
+const SHARED_OPTIONS = {
+  deliverables: ["xlsx"],
+  search: { startDate: "2019-01-01", includedSources: ["finance"] },
+  previousReports: ["dr_a", "dr_b"],
+  hitl: { planReview: true },
+  urls: ["https://example.com"],
+  mcpServers: [{ name: "srv", url: "https://mcp.example.com" }],
+  brandCollectionId: "brand_1",
+  metadata: { deal: "project-frost" },
+  tools: { code_execution: { enabled: true, max_calls: 5 } },
+  webhookUrl: "https://example.com/hook",
+  alertEmail: "analyst@example.com",
+} as any;
+
+/** The snake_case body the shared options are expected to serialise into. */
+const EXPECTED_WIRE_FIELDS = {
+  deliverables: ["xlsx"],
+  search: { start_date: "2019-01-01", included_sources: ["finance"] },
+  previous_reports: ["dr_a", "dr_b"],
+  hitl: { plan_review: true },
+  urls: ["https://example.com"],
+  mcp_servers: [{ name: "srv", url: "https://mcp.example.com" }],
+  brand_collection_id: "brand_1",
+  metadata: { deal: "project-frost" },
+  tools: { code_execution: { enabled: true, max_calls: 5 } },
+  webhook_url: "https://example.com/hook",
+  alert_email: "analyst@example.com",
+};
+
+function makeClient() {
+  const valyu = new Valyu("val_test");
+  const post = jest
+    .fn()
+    .mockResolvedValue({ data: { deepresearch_id: "dr_123", status: "queued" } });
+  (valyu as any).client = { post };
+  return { valyu, post };
+}
+
+/** The JSON body handed to client.post. */
+function sentPayload(post: jest.Mock) {
+  return post.mock.calls[0][1];
+}
+
+describe("workflow run payload", () => {
+  it("forwards every per-run option", async () => {
+    const { valyu, post } = makeClient();
+
+    const result = await valyu.deepresearch.create({
+      workflowId: "ib-comps-analysis",
+      workflowParams: { target: "Datadog (DDOG)" },
+      ...SHARED_OPTIONS,
+    });
+
+    expect(result.success).toBe(true);
+    const payload = sentPayload(post);
+    expect(payload.workflow_id).toBe("ib-comps-analysis");
+    expect(payload.workflow_params).toEqual({ target: "Datadog (DDOG)" });
+    for (const [key, value] of Object.entries(EXPECTED_WIRE_FIELDS)) {
+      expect(payload[key]).toEqual(value);
+    }
+  });
+
+  it("serialises per-run options identically to a freeform run", async () => {
+    const workflow = makeClient();
+    await workflow.valyu.deepresearch.create({
+      workflowId: "ib-comps-analysis",
+      workflowParams: { target: "Datadog (DDOG)" },
+      ...SHARED_OPTIONS,
+    });
+
+    const freeform = makeClient();
+    await freeform.valyu.deepresearch.create({
+      query: "a freeform query",
+      ...SHARED_OPTIONS,
+    });
+
+    const workflowPayload = sentPayload(workflow.post);
+    const freeformPayload = sentPayload(freeform.post);
+    for (const key of Object.keys(EXPECTED_WIRE_FIELDS)) {
+      expect(workflowPayload[key]).toEqual(freeformPayload[key]);
+    }
+  });
+
+  it("stays minimal when no per-run options are set", async () => {
+    const { valyu, post } = makeClient();
+
+    await valyu.deepresearch.create({
+      workflowId: "ib-company-profile",
+      workflowParams: { company: "NVIDIA (NVDA)" },
+    });
+
+    expect(sentPayload(post)).toEqual({
+      workflow_id: "ib-company-profile",
+      workflow_params: { company: "NVIDIA (NVDA)" },
+    });
+  });
+
+  it("applies the files[].context cap", async () => {
+    const { valyu, post } = makeClient();
+
+    const result = await valyu.deepresearch.create({
+      workflowId: "ib-company-profile",
+      workflowParams: { company: "NVIDIA (NVDA)" },
+      files: [{ url: "https://example.com/a.pdf", context: "x".repeat(10001) }],
+    } as any);
+
+    expect(post).not.toHaveBeenCalled();
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("files[0].context exceeds 10,000 character limit");
+  });
+
+  it("stays mutually exclusive with the template-supplied fields", async () => {
+    const { valyu, post } = makeClient();
+
+    const result = await valyu.deepresearch.create({
+      workflowId: "ib-company-profile",
+      workflowParams: { company: "NVIDIA (NVDA)" },
+      query: "a freeform query",
+    });
+
+    expect(post).not.toHaveBeenCalled();
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("mutually exclusive");
+  });
+});
+
+describe("SDK version", () => {
+  it("matches package.json", async () => {
+    const { valyu, post } = makeClient();
+    await valyu.deepresearch.create({
+      workflowId: "ib-company-profile",
+      workflowParams: { company: "NVIDIA (NVDA)" },
+    });
+
+    // Reported on every request, so a constant that drifts from the published
+    // version misreports which build a request came from.
+    const headers = (valyu as any).headers;
+    expect(headers["x-valyu-sdk-version"] ?? headers["X-Valyu-SDK-Version"]).toBe(
+      packageVersion
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Running a workflow through `deepresearch.create()` silently discarded most of the options passed alongside it. The workflow branch built its own, much smaller payload, so these never reached the wire:

`deliverables`, `search`, `previousReports`, `hitl`, `urls`, `files`, `mcpServers`, `brandCollectionId`, `codeExecution`

The API accepts all of them on a workflow run and lets a request-body value override the template, so passing them was a no-op rather than an error — the run just quietly used the template defaults.

Mirrors the same fix in the Python SDK.

## What changed

**Per-run options now reach the wire on workflow runs.** Both code paths build the shared fields through one helper, so their camelCase → snake_case mapping is identical by construction rather than by two lists staying in sync.

The workflow branch keeps its own handling of the genuinely template-supplied fields:
- `mode` and `outputFormats` are still only sent when explicitly set, so a workflow's recommended defaults apply otherwise
- `query` / `strategy` / `reportFormat` remain mutually exclusive with `workflowId`
- the `files[].context` length guard now applies to workflow runs too

**Validation errors now name the offending field.** The API returns an `errors` array identifying each problem; only the summary was kept. A wrong `workflowParams` key used to produce:

```
validation_failed
```

and now produces:

```
2 validation errors: Unknown parameter "company"; Required parameter "target" is missing
```

That matters because workflows declare different variable names — `ib-company-profile` takes `company`, `ib-comps-analysis` takes `target`, `ib-precedent-transactions` takes `sector` — so a caller guessing the wrong key previously had nothing to go on. Applied to `deepresearch.create()` and the `workflows` methods.

**Version bumped to 2.10.0**, with a test pinning `SDK_VERSION` to the `package.json` version. It ships as `X-Valyu-SDK-Version` on every request, so a constant that drifts misreports which build a request came from.

## Verification

`tsc --noEmit` clean, 14 tests pass, including new coverage that the two code paths serialise per-run options identically, that a bare workflow run stays minimal so template defaults still apply, and that the mutual-exclusion and `files[].context` guards still fire.

Checked the built bundle against the live API — a workflow run now emits `search`, `deliverables`, `previous_reports` and `hitl`, and the validation message above is the real response.

## Compatibility

No signature changes and no behaviour change for freeform runs. Workflow runs that already passed these options will start having them applied, which is the documented behaviour; a run that relied on them being ignored would need them removed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/valyuAI/codesmith/valyu-js/pr/172"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787834311&installation_model_id=424733&pr_number=172&repository=valyuAI%2Fvalyu-js&return_to=https%3A%2F%2Fgithub.com%2FvalyuAI%2Fvalyu-js%2Fpull%2F172&signature=cbc26b0b226eea30c55661ba48a199403ab50c8de643e953256a1e8afc1a6afb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->